### PR TITLE
Unnecessary request of permission to save to library when capture is set to false

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -526,34 +526,34 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
                 capturedImage = [UIImage imageWithCGImage:imageRef scale:capturedImage.scale orientation:UIImageOrientationUp];
                 imageData = UIImageJPEGRepresentation(capturedImage, 0.85f);
                 
-                [PHPhotoLibrary requestAuthorization:^( PHAuthorizationStatus status ) {
-                    if ( status == PHAuthorizationStatusAuthorized ) {
-                        
-                        NSMutableDictionary *imageInfoDict = [[NSMutableDictionary alloc] init];
-                        
-                        NSURL *temporaryFileURL = [CKCamera saveToTmpFolder:imageData];
-                        if (temporaryFileURL) {
-                            imageInfoDict[@"uri"] = temporaryFileURL.description;
-                            imageInfoDict[@"name"] = temporaryFileURL.lastPathComponent;
-                        }
-                        imageInfoDict[@"size"] = [NSNumber numberWithInteger:imageData.length];
-                        
-                        if (capturedImage && [capturedImage isKindOfClass:[UIImage class]]) {
-                            imageInfoDict[@"width"] = [NSNumber numberWithDouble:capturedImage.size.width];
-                            imageInfoDict[@"height"] = [NSNumber numberWithDouble:capturedImage.size.height];
-                        }
-                        
-                        
-                        if (shouldSaveToCameraRoll) {
+                //Prepare image info dict
+                NSMutableDictionary *imageInfoDict = [[NSMutableDictionary alloc] init];
+
+                NSURL *temporaryFileURL = [CKCamera saveToTmpFolder:imageData];
+                if (temporaryFileURL) {
+                    imageInfoDict[@"uri"] = temporaryFileURL.description;
+                    imageInfoDict[@"name"] = temporaryFileURL.lastPathComponent;
+                }
+                imageInfoDict[@"size"] = [NSNumber numberWithInteger:imageData.length];
+
+                if (capturedImage && [capturedImage isKindOfClass:[UIImage class]]) {
+                    imageInfoDict[@"width"] = [NSNumber numberWithDouble:capturedImage.size.width];
+                    imageInfoDict[@"height"] = [NSNumber numberWithDouble:capturedImage.size.height];
+                }
+                
+                //Check if save to camera roll is set to true
+                if (shouldSaveToCameraRoll) {
+                    [PHPhotoLibrary requestAuthorization:^( PHAuthorizationStatus status ) {
+                        if ( status == PHAuthorizationStatusAuthorized ) {
                             NSData *compressedImageData = UIImageJPEGRepresentation(capturedImage, 1.0f);
-                            
+
                             [CKGalleryManager saveImageToCameraRoll:compressedImageData temporaryFileURL:temporaryFileURL block:^(BOOL success) {
                                 if (success) {
                                     NSString *localIdentifier = [CKGalleryManager getImageLocalIdentifierForFetchOptions:self.fetchOptions];
                                     if (localIdentifier) {
                                         imageInfoDict[@"id"] = localIdentifier;
                                     }
-                                    
+
                                     if (block) {
                                         block(imageInfoDict);
                                     }
@@ -562,11 +562,11 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
                                     //NSLog( @"Could not save to camera roll");
                                 }
                             }];
-                        } else if (block) {
-                            block(imageInfoDict);
                         }
-                    }
-                }];
+                    }];
+                } else if (block) {
+                    block(imageInfoDict);
+                }
                 
                 CGImageRelease(imageRef);
             }

--- a/src/CameraKitCamera.android.js
+++ b/src/CameraKitCamera.android.js
@@ -2,8 +2,9 @@ import * as _ from 'lodash';
 import React, { Component } from 'react';
 import {
 	requireNativeComponent,
-  NativeModules,
-  processColor
+  	NativeModules,
+  	processColor,
+	PermissionsAndroid
 } from 'react-native';
 
 const NativeCamera = requireNativeComponent('CameraView', null);
@@ -27,9 +28,17 @@ export default class CameraKitCamera extends React.Component {
     console.log('flashMode?', await NativeCameraModule.getFlashMode());
   }
 
-  static async requestDeviceCameraAuthorization() {
-    const usersAuthorizationAnswer = await NativeCameraModule.requestDeviceCameraAuthorization();
-    return usersAuthorizationAnswer;
+  static requestDeviceCameraAuthorization() {
+    return new Promise((resolve, reject) => {
+      PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.CAMERA
+      ).then(result => {
+        if (result == PermissionsAndroid.RESULTS.GRANTED || result == true)
+          resolve(true);
+        else
+          resolve(false)
+      })
+    });
   }
 
   async capture(saveToCameraRoll = true) {


### PR DESCRIPTION
The camera should only check for library permission or execute the `PHLibrary` when `this.camera.capture(true)` is being passed.
Code has been updated to remove the unnecessary execution of library permission even though component is not being used for it.