### PR TITLE
Pass shouldSaveToCameraRoll as a prop to control saving photos to camera roll

### DIFF
--- a/src/CameraScreen/CameraKitCameraScreenBase.js
+++ b/src/CameraScreen/CameraKitCameraScreenBase.js
@@ -28,10 +28,12 @@ export default class CameraScreenBase extends Component {
 
   static propTypes = {
     allowCaptureRetake: PropTypes.bool,
+    shouldSaveToCameraRoll: PropTypes.bool
   };
 
   static defaultProps = {
     allowCaptureRetake: false,
+    shouldSaveToCameraRoll: true
   };
 
   constructor(props) {
@@ -290,8 +292,7 @@ export default class CameraScreenBase extends Component {
   }
 
   async onCaptureImagePressed() {
-    const shouldSaveToCameraRoll = !this.props.allowCaptureRetake;
-    const image = await this.camera.capture(shouldSaveToCameraRoll);
+    const image = await this.camera.capture(this.props.shouldSaveToCameraRoll);
 
     if (this.props.allowCaptureRetake) {
       this.setState({ imageCaptured: image });

--- a/src/CameraScreen/CameraKitCameraScreenBase.js
+++ b/src/CameraScreen/CameraKitCameraScreenBase.js
@@ -292,6 +292,8 @@ export default class CameraScreenBase extends Component {
   }
 
   async onCaptureImagePressed() {
+    this.sendBottomButtonPressedAction('processing', false, {});
+    
     const image = await this.camera.capture(this.props.shouldSaveToCameraRoll);
 
     if (this.props.allowCaptureRetake) {


### PR DESCRIPTION
**Scenario:**
As a developer, I want to be able to control when photos are going to be saved when using the `CameraKitCameraScreen` module. For example, if I want to apply image manipulation to the initial photo taken by the user (e.g. adding a logo) without having to save the initial photo taken.

The `CameraKitCameraScreen` module currently does not read the `shouldSaveToCameraRoll` from the `props`. This PR fixes this issue by reading `shouldSaveToCameraRoll` as a prop.

Passing `shouldSaveToCameraRoll` as `true` will save the photo captured to camera roll and false won't save it to camera roll. The default value is `true` (to keep backwards compatibility).

Example:
```
<CameraKitCameraScreen
        shouldSaveToCameraRoll={false}
        actions={{rightButtonText: 'Done', leftButtonText: 'Cancel'}}
        onBottomButtonPressed={(event) => {
          onCapture(event)
        }}
        flashImages={{
          on: require('../../assets/flashOn.png'),
          off: require('../../assets/flashOff.png'),
          auto: require('../../assets/flashAuto.png'),
        }}
        cameraFlipImage={require('../../assets/cameraFlip.png')}
        captureButtonImage={require('../../assets/cameraButton.png')}
      />
```

I have tested this on iPhone 6s Plus running iOS 11.3.1 and Galaxy S4 Android 5.0.1

Would be great if someone can review this trivial fix? Maybe @gran33 ?
Thanks.