### PR TITLE
Fix android crash before permission request

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Advanced native camera control with pre-defined aspect ratio, crop, etc",
   "author": "Ran Greenberg <rang@wix.com>",
   "nativePackage": true,


### PR DESCRIPTION
There is inconsistency with checkAuthorizationStatus return type
heckAuthorizationStatus returns local static finals
but within isPermissionGranted was compared against PermissionChecker consts which has different declarations
it caused requestDeviceCameraAuthorization to resolve before actual permissions was granted.