### PR TITLE
CI: Validate Gradle Wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
       steps:
         - name: Checkout
           uses: actions/checkout@v2
+        - name: Validate Gradle Wrapper
+          uses: gradle/wrapper-validation-action@v1
         - name: Install modules
           run: yarn
         - name: Bootstrap


### PR DESCRIPTION
Checks that the `gradle-wrapper.jar` files are valid and not malicious. Current output:
```
✓ Found known Gradle Wrapper JAR files:
  16caeaf66d57a0d1d2087fef6a97efa62de8da69afa5b908f40db35afc4342da android/gradle/wrapper/gradle-wrapper.jar
  3dc39ad650d40f6c029bd8ff605c6d95865d657dbfdeacdb079db0ddfffedf9f example/android/gradle/wrapper/gradle-wrapper.jar
```
See the [Gradle Wrapper Validation Action](https://github.com/gradle/wrapper-validation-action) for more context.