### PR TITLE
CI: Add --warning-mode=fail to Gradle build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
         - name: Bootstrap
           run: yarn bootstrap
         - name: Build
-          run: cd example/android && ./gradlew assembleDebug
+          run: cd example/android && ./gradlew assembleDebug --warning-mode=fail


### PR DESCRIPTION
Added `--warning-mode=fail` to the Gradle build to let the CI fail if any warnings are thrown.

If this passes, the build will be ready for Gradle 7.0.