### PR TITLE
Adding null safety check on RNCameraKitModule

### DIFF
--- a/android/src/main/java/com/rncamerakit/RNCameraKitModule.kt
+++ b/android/src/main/java/com/rncamerakit/RNCameraKitModule.kt
@@ -33,7 +33,7 @@ class RNCameraKitModule(private val reactContext: ReactApplicationContext) : Rea
         val context = reactContext
         val uiManager = context.getNativeModule(UIManagerModule::class.java)
         context.runOnUiQueueThread {
-            val view = uiManager.resolveView(viewTag) as CKCamera
+            val view = uiManager?.resolveView(viewTag) as CKCamera
             view.capture(options.toHashMap(), promise)
         }
     }


### PR DESCRIPTION
with react-native 0.64.0, this occurs null safety check error. 
