### PR TITLE
Updated Camera object to be instance of forwardRef function

### DIFF
--- a/src/Camera.android.tsx
+++ b/src/Camera.android.tsx
@@ -5,7 +5,7 @@ import { requireNativeComponent, findNodeHandle, NativeModules, processColor } f
 const { RNCameraKitModule } = NativeModules;
 const NativeCamera = requireNativeComponent('CKCameraManager');
 
-function Camera(props, ref) {
+const Camera = React.forwardRef((props, ref) => {
   const nativeRef = React.useRef();
 
   React.useImperativeHandle(ref, () => ({
@@ -32,10 +32,10 @@ function Camera(props, ref) {
       ref={nativeRef}
       {...transformedProps}
     />);
-}
+});
 
 const { PORTRAIT, PORTRAIT_UPSIDE_DOWN, LANDSCAPE_LEFT, LANDSCAPE_RIGHT } = RNCameraKitModule.getConstants();
 
 export { PORTRAIT, PORTRAIT_UPSIDE_DOWN, LANDSCAPE_LEFT, LANDSCAPE_RIGHT };
 
-export default React.forwardRef(Camera);
+export default Camera;

--- a/src/Camera.ios.tsx
+++ b/src/Camera.ios.tsx
@@ -5,7 +5,7 @@ import { requireNativeComponent, NativeModules, processColor } from 'react-nativ
 const { CKCameraManager } = NativeModules;
 const NativeCamera = requireNativeComponent('CKCamera');
 
-function Camera(props, ref) {
+const Camera = React.forwardRef((props, ref) => {
   const nativeRef = React.useRef();
 
   React.useImperativeHandle(ref, () => ({
@@ -24,7 +24,7 @@ function Camera(props, ref) {
   _.update(transformedProps, 'cameraOptions.ratioOverlayColor', (c) => processColor(c));
 
   return <NativeCamera style={{ minWidth: 100, minHeight: 100 }} ref={nativeRef} {...transformedProps} />;
-}
+});
 
 Camera.defaultProps = {
   resetFocusTimeout: 0,
@@ -32,4 +32,4 @@ Camera.defaultProps = {
   saveToCameraRoll: true,
 };
 
-export default React.forwardRef(Camera);
+export default Camera;


### PR DESCRIPTION
I made this to fix the warning brought up here #391 

Essentially, default props were being applied incorrectly, maybe due to a refactor in the past. I just swapped things around so it applies the default props to returned fowardRef function (which behaves similar to a component). I've attached a thread explaining the issue in more detail [Thread](https://github.com/facebook/react/issues/16653)