### PR TITLE
Fix MimeType for API 30

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -16,7 +16,6 @@ import android.provider.MediaStore
 import android.util.DisplayMetrics
 import android.util.Log
 import android.view.*
-import android.webkit.MimeTypeMap
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
@@ -284,7 +283,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
         // Create output options object which contains file + metadata
         val contentValues = ContentValues().apply {
             put(MediaStore.MediaColumns.DISPLAY_NAME, "IMG_" + System.currentTimeMillis())
-            put(MediaStore.MediaColumns.MIME_TYPE, MimeTypeMap.getSingleton().getMimeTypeFromExtension("jpg"))
+            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
         }
 
         // Create the output file option to store the captured image in MediaStore

--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -283,7 +283,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
         // Create output options object which contains file + metadata
         val contentValues = ContentValues().apply {
             put(MediaStore.MediaColumns.DISPLAY_NAME, "IMG_" + System.currentTimeMillis())
-            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpg")
+            put(MediaStore.MediaColumns.MIME_TYPE, MimeTypeMap.getSingleton().getMimeTypeFromExtension("jpg"))
         }
 
         // Create the output file option to store the captured image in MediaStore

--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -16,6 +16,7 @@ import android.provider.MediaStore
 import android.util.DisplayMetrics
 import android.util.Log
 import android.view.*
+import android.webkit.MimeTypeMap
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt


### PR DESCRIPTION
On Android 30, MimeType "image/jpg" fails for MediaStore, on capture in CKCamera. 
Use MimeTypeMap to get correct mime type from extension instead