### PR TITLE
package.json should have source path

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "source": "./src/",
   "dependencies": {
     "lodash": "^4.14.2"
   },


### PR DESCRIPTION
This is required by the example's babel config.

## Summary
This makes it easier to run the example, see [babel.config.js](https://github.com/teslamotors/react-native-camera-kit/blob/master/example/babel.config.js#L11).

## How did you test this change?
I ran the example.