### PR TITLE
Upgrade dependencies to latest stable; show square on tap-to-focus

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 23
@@ -23,10 +23,10 @@ dependencies {
     implementation group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.12.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "androidx.camera:camera-core:1.0.0-rc01"
-    implementation "androidx.camera:camera-camera2:1.0.0-rc01"
-    implementation "androidx.camera:camera-lifecycle:1.0.0-rc01"
-    implementation "androidx.camera:camera-view:1.0.0-alpha20"
+    implementation "androidx.camera:camera-core:1.0.2"
+    implementation "androidx.camera:camera-camera2:1.0.2"
+    implementation "androidx.camera:camera-lifecycle:1.0.2"
+    implementation "androidx.camera:camera-view:1.0.0-alpha32"
 
     implementation 'com.google.mlkit:barcode-scanning:16.0.3'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Dec 28 10:00:20 PST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/android/src/main/java/com/rncamerakit/CKCameraManager.kt
+++ b/android/src/main/java/com/rncamerakit/CKCameraManager.kt
@@ -3,7 +3,6 @@ package com.rncamerakit
 import android.graphics.Color
 import android.util.Log
 import androidx.annotation.ColorInt
-import androidx.camera.view.CameraView
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.common.MapBuilder

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "28.0.3"
         minSdkVersion = 23
-        compileSdkVersion = 30
+        compileSdkVersion = 31
         targetSdkVersion = 28
         kotlin_version = '1.4.10'
     }

--- a/src/CameraScreen.tsx
+++ b/src/CameraScreen.tsx
@@ -154,7 +154,7 @@ export default class CameraScreen extends Component<Props, State> {
       !this.isCaptureRetakeMode() && (
         <TouchableOpacity style={{ paddingHorizontal: 15 }} onPress={() => this.onSwitchCameraPressed()}>
           <Image
-            style={[{ flex: 1, justifyContent: 'center' }, this.props.cameraImageStyle]}
+            style={{ flex: 1, justifyContent: 'center' }}
             source={this.props.cameraFlipImage}
             resizeMode="contain"
           />


### PR DESCRIPTION
## Summary

The goals of this change are to use the latest stable versions of the camera X API; and to bring the iOS and Android versions closer together, by showing a square on focus.

## How did you test this change?

No iOS changes, but let me know if I should anyway test.

Android test:
![image](https://user-images.githubusercontent.com/747519/150422663-2bf65b4c-57c6-4da8-8b1a-88820265470d.png)

