### PR TITLE
fix: resolve saveToCameraRoll issue

### DIFF
--- a/src/CameraScreen.tsx
+++ b/src/CameraScreen.tsx
@@ -44,6 +44,7 @@ export type Props = {
   frameColor: any,
   torchOnImage: any,
   torchOffImage: any,
+  saveToCameraRoll: boolean,
 
   torchImageStyle: ImageStyle,
   onReadCode: (event: any) => void;
@@ -190,12 +191,13 @@ export default class CameraScreen extends Component<Props, State> {
             focusMode={this.props.focusMode}
             zoomMode={this.props.zoomMode}
             ratioOverlay={this.state.ratios[this.state.ratioArrayPosition]}
-            saveToCameraRoll={!this.props.allowCaptureRetake}
+            saveToCameraRoll={this.props.saveToCameraRoll}
             showFrame={this.props.showFrame}
             scanBarcode={this.props.scanBarcode}
             laserColor={this.props.laserColor}
             frameColor={this.props.frameColor}
             onReadCode={this.props.onReadCode}
+            
           />
         )}
       </View>

--- a/src/CameraScreen.tsx
+++ b/src/CameraScreen.tsx
@@ -44,7 +44,7 @@ export type Props = {
   frameColor: any,
   torchOnImage: any,
   torchOffImage: any,
-  saveToCameraRoll: boolean,
+  saveToCameraRoll?: boolean,
 
   torchImageStyle: ImageStyle,
   onReadCode: (event: any) => void;


### PR DESCRIPTION
Prop saveToCameraRoll didn't work because of incorrect prop (!this.props.allowCaptureRetake} being passed. If allowCaptureRetake was passed as true, then a black screen showed up because of the condition  this.isCaptureRetakeMode() ? . Requesting @scarlac and @DibyajyotiMishra for the review.