### PR TITLE
Fix iOS crash when permisions denied

### DIFF
--- a/ios/ReactNativeCameraKit/CKCamera.m
+++ b/ios/ReactNativeCameraKit/CKCamera.m
@@ -658,7 +658,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 
 - (void)changeCamera:(AVCaptureDevicePosition)preferredPosition
 {
-    // Avoid chaning device inputs when camera input is denied by the user, since both front and rear vido input devices will be nill
+    // Avoid chaning device inputs when camera input is denied by the user, since both front and rear vido input devices will be nil
     if ( self.setupResult != CKSetupResultSuccess ) {
         return;
     }

--- a/ios/ReactNativeCameraKit/CKCamera.m
+++ b/ios/ReactNativeCameraKit/CKCamera.m
@@ -658,6 +658,10 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 
 - (void)changeCamera:(AVCaptureDevicePosition)preferredPosition
 {
+    // Avoid chaning device inputs when camera input is denied by the user, since both front and rear vido input devices will be nill
+    if ( self.setupResult != CKSetupResultSuccess ) {
+        return;
+    }
 #if TARGET_IPHONE_SIMULATOR
     dispatch_async( dispatch_get_main_queue(), ^{
         [self.mockPreview randomize];


### PR DESCRIPTION
Fixes #395 
- Don't attempt to swap camera inputs when permissions are denied.

## Summary

Setting the `cameraType` value explicitly causes the `changeCamera` function on **iOS** to fire that attempts to switch device inputs that are `nil` due to permissions being denied. 

The `CameraScreen` wrapper around `Camera` sets this prop to `CameraType.Back` by default thus why it crashes on `CameraScreen` and not on `Camera` 

The `Camera` component doesn't set this prop by default and is left as `undefined` and thus doesn't change and trigger the `changeCamera` function on **iOS**

## How did you test this change?

**iOS** Tested on physical device iPhone 13 Mini (iOS 15.3.1) 
**Android**  N/A

https://user-images.githubusercontent.com/9149232/162102360-9bb1b0de-b26b-4ee7-b9ec-06eeac5fe2c9.MP4


