### PR TITLE
fix orientation problem, fix scanner problem

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -294,7 +294,7 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
-  - ReactNativeCameraKit (11.2.0):
+  - ReactNativeCameraKit (12.0.0):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -458,10 +458,10 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  ReactNativeCameraKit: c25ef4c32abd8918578a9ece01c90233f478c97c
+  ReactNativeCameraKit: 9a5413e452499bd63e8c13c50de4b34d78a5f1f1
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: f9ef8a8a0dbf13b0a1ceaa5b4c54937559d74e9e
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,60 +1,78 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import {
   StyleSheet,
   Text,
   View,
   TouchableOpacity,
+  useWindowDimensions,
+  SafeAreaView,
+  ScrollView,
 } from 'react-native';
 
 import CameraScreenExample from './CameraScreenExample';
 import BarcodeScreenExample from './BarcodeScreenExample';
 import CameraExample from './CameraExample';
 
-type State = {
-  example?: CameraExample | CameraScreenExample | BarcodeScreenExample;
+const isOrientationPortrait = (width: number, height: number) => height >= width;
+
+type SimpleContainerProps = {
+  children: any;
+  goHome: () => void;
+};
+function SimpleContainer(props: SimpleContainerProps) {
+  const { height, width } = useWindowDimensions();
+  const isPortrait = isOrientationPortrait(width, height);
+  const orientation: string = isPortrait ? 'portrait' : 'landscape';
+  const tipText = `width:${width},height:${height},orientation:${orientation}`;
+  return (
+    <SafeAreaView style={styles.flex1}>
+      <View style={styles.flex1}>
+        <View style={[styles.flexDirectionRow, styles.bgCCC]}>
+          <TouchableOpacity onPress={props.goHome} style={styles.marginRight20}>
+            <Text style={{ color: 'blue' }}>Go Home</Text>
+          </TouchableOpacity>
+          <Text>{tipText}</Text>
+        </View>
+        <View style={[styles.flex1, styles.border1red]}>{props.children}</View>
+      </View>
+    </SafeAreaView>
+  );
 }
 
-export default class App extends Component {
-  state: State;
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      example: undefined,
-    };
-  }
-
-  render() {
-    if (this.state.example) {
-      const Example = this.state.example;
-      return <Example />;
-    }
+type AppState = {
+  example: Function | null;
+};
+export default function App() {
+  const [state, setState] = useState<AppState>({ example: null });
+  const goHome = () => setState({ example: null });
+  if (state.example) {
+    const Example: any = state.example;
     return (
-      <View style={{ flex: 1 }}>
-        <View style={styles.headerContainer}>
-          <Text style={{ fontSize: 60 }}>🎈</Text>
-          <Text style={styles.headerText}>
-            React Native Camera Kit
-          </Text>
-        </View>
-        <View style={styles.container}>
-          <TouchableOpacity style={styles.button} onPress={() => this.setState({ example: CameraExample })}>
-            <Text style={styles.buttonText}>
-              Camera
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.button} onPress={() => this.setState({ example: CameraScreenExample })}>
-            <Text style={styles.buttonText}>
-              Camera Screen
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.button} onPress={() => this.setState({ example: BarcodeScreenExample })}>
-            <Text style={styles.buttonText}>
-              Barcode Scanner
-            </Text>
-          </TouchableOpacity>
-        </View>
-      </View>
+      <SimpleContainer goHome={goHome}>
+        <Example />
+      </SimpleContainer>
+    );
+  } else {
+    return (
+      <SimpleContainer goHome={goHome}>
+        <ScrollView style={{ flex: 1 }}>
+          <View style={styles.headerContainer}>
+            <Text style={{ fontSize: 60 }}>🎈</Text>
+            <Text style={styles.headerText}>React Native Camera Kit</Text>
+          </View>
+          <View style={styles.container}>
+            <TouchableOpacity style={styles.button} onPress={() => setState({ example: CameraExample })}>
+              <Text style={styles.buttonText}>Camera</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.button} onPress={() => setState({ example: CameraScreenExample })}>
+              <Text style={styles.buttonText}>Camera Screen</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.button} onPress={() => setState({ example: BarcodeScreenExample })}>
+              <Text style={styles.buttonText}>Barcode Scanner</Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </SimpleContainer>
     );
   }
 }
@@ -63,7 +81,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: 30,
-    alignItems: 'center',
     backgroundColor: '#F5FCFF',
     marginHorizontal: 24,
   },
@@ -83,12 +100,25 @@ const styles = StyleSheet.create({
     height: 60,
     borderRadius: 30,
     marginVertical: 12,
-    width: '100%',
     backgroundColor: '#dddddd',
     justifyContent: 'center',
   },
   buttonText: {
     textAlign: 'center',
     fontSize: 20,
+  },
+  flexDirectionRow: {
+    flexDirection: 'row',
+  },
+  bgCCC: {
+    backgroundColor: '#ccc',
+  },
+  flex1: { flex: 1 },
+  border1red: {
+    borderWidth: 1,
+    borderColor: 'red',
+  },
+  marginRight20: {
+    marginRight: 20,
   },
 });

--- a/ios/ReactNativeCameraKit.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeCameraKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D37AE2827FFDA6800FC4EB4 /* CKScannerOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D37AE2727FFDA6800FC4EB4 /* CKScannerOverlay.m */; };
 		26550AF61CFC7086007FF2DF /* CKCameraManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 26550AF51CFC7086007FF2DF /* CKCameraManager.m */; };
 		2685AA241CFD89A300E4A446 /* CKCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 2685AA231CFD89A300E4A446 /* CKCamera.m */; };
 		269292831D3B7D6000E07DDF /* CKCameraOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 269292821D3B7D6000E07DDF /* CKCameraOverlayView.m */; };
@@ -28,6 +29,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0D37AE2627FFDA6800FC4EB4 /* CKScannerOverlay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CKScannerOverlay.h; sourceTree = "<group>"; };
+		0D37AE2727FFDA6800FC4EB4 /* CKScannerOverlay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CKScannerOverlay.m; sourceTree = "<group>"; };
 		2646934E1CFB2A6B00F3A740 /* libReactNativeCameraKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativeCameraKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		26550AF41CFC7086007FF2DF /* CKCameraManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKCameraManager.h; sourceTree = "<group>"; };
 		26550AF51CFC7086007FF2DF /* CKCameraManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CKCameraManager.m; sourceTree = "<group>"; };
@@ -85,6 +88,8 @@
 				269292851D3B81C800E07DDF /* CKOverlayObject.m */,
 				FC8E10CD253F8A23006D5AD0 /* CKMockPreview.h */,
 				FC8E10CE253F8A23006D5AD0 /* CKMockPreview.m */,
+				0D37AE2627FFDA6800FC4EB4 /* CKScannerOverlay.h */,
+				0D37AE2727FFDA6800FC4EB4 /* CKScannerOverlay.m */,
 			);
 			path = ReactNativeCameraKit;
 			sourceTree = "<group>";
@@ -151,6 +156,7 @@
 				A7686BFE1EC9CFEC00959216 /* CKCompressedImage.m in Sources */,
 				269292861D3B81C800E07DDF /* CKOverlayObject.m in Sources */,
 				2685AA241CFD89A300E4A446 /* CKCamera.m in Sources */,
+				0D37AE2827FFDA6800FC4EB4 /* CKScannerOverlay.m in Sources */,
 				269292831D3B7D6000E07DDF /* CKCameraOverlayView.m in Sources */,
 				FC8E10CF253F8A23006D5AD0 /* CKMockPreview.m in Sources */,
 			);

--- a/ios/ReactNativeCameraKit/CKScannerOverlay.h
+++ b/ios/ReactNativeCameraKit/CKScannerOverlay.h
@@ -1,0 +1,13 @@
+#import <UIKit/UIKit.h>
+
+@interface CKScannerOverlay: UIView
+@property (nonatomic, strong) UIView *topView, *leftSideView,*rightSideView,*bottomView;
+@property (nonatomic, strong) NSArray *cornerViews;
+@property (nonatomic, strong) UIView *dataReadingFrame;
+@property (nonatomic) CGFloat frameOffset;
+@property (nonatomic) CGFloat frameHeight;
+@property (nonatomic) UIView *scannerView;
+@property (nonatomic, strong) UIColor *laserColor;
+@property (nonatomic, strong) UIColor *frameColor;
+@property (nonatomic, assign) BOOL shouldAnimating;
+@end

--- a/ios/ReactNativeCameraKit/CKScannerOverlay.m
+++ b/ios/ReactNativeCameraKit/CKScannerOverlay.m
@@ -1,0 +1,126 @@
+#import "CKScannerOverlay.h"
+
+@implementation CKScannerOverlay
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.frameOffset = 30;
+        self.frameHeight = 200;
+
+        self.dataReadingFrame = [UIView new];
+        [self addSubview:self.dataReadingFrame];
+
+        self.cornerViews = @[[UIView new],[UIView new],[UIView new],[UIView new],[UIView new],[UIView new],[UIView new],[UIView new]];
+        for (UIView *view in self.cornerViews) {
+            [self.dataReadingFrame addSubview:view];
+        }
+
+        self.topView = [UIView new];
+        self.leftSideView = [UIView new];
+        self.rightSideView = [UIView new];
+        self.bottomView = [UIView new];
+        [self addSubview:self.topView];
+        [self addSubview:self.leftSideView];
+        [self addSubview:self.rightSideView];
+        [self addSubview:self.bottomView];
+
+    }
+    return self;
+}
+
+- (void)layoutSubviews{
+    [self layoutDataReadingFrame];
+    [self layoutCornerViews];
+    [self layoutDimmedViews];
+    if (self.shouldAnimating) {
+        [self createScannerViewAndAnimate];
+    } else {
+        [self.scannerView removeFromSuperview];
+        self.scannerView = nil;
+    }
+}
+
+- (void)layoutDataReadingFrame {
+    CGFloat frameWidth = self.bounds.size.width - 2 * self.frameOffset;
+    self.dataReadingFrame.frame = CGRectMake(0, 0, frameWidth, self.frameHeight);
+    self.dataReadingFrame.center = self.center;
+    self.dataReadingFrame.backgroundColor = [UIColor clearColor];
+}
+
+- (void)createScannerViewAndAnimate {
+    if (self.scannerView) {
+        [self.scannerView removeFromSuperview];
+    }
+    self.scannerView = [[UIView alloc] initWithFrame:CGRectMake(2, 0, self.dataReadingFrame.frame.size.width - 4, 2)];
+    self.scannerView.backgroundColor = self.laserColor;
+
+    if (self.scannerView.frame.origin.y != 0) {
+        [self.scannerView setFrame:CGRectMake(2, 0, self.dataReadingFrame.frame.size.width - 4, 2)];
+    }
+    [self.dataReadingFrame addSubview:self.scannerView];
+    [UIView animateWithDuration:3 delay:0 options:(UIViewAnimationOptionAutoreverse | UIViewAnimationOptionRepeat) animations:^{
+        CGFloat middleX = self.dataReadingFrame.frame.size.width / 2;
+        self.scannerView.center = CGPointMake(middleX, self.dataReadingFrame.frame.size.height - 1);
+    } completion:^(BOOL finished) {}];
+}
+
+
+// dimmed views are rectangles placed on the top left right bottom
+- (void)layoutDimmedViews {
+    UIColor *bgColor = [UIColor colorWithRed:0.0/255.0 green:0.0/255.0 blue:0.0/255.0 alpha:0.4];
+    self.topView.backgroundColor = self.leftSideView.backgroundColor = self.rightSideView.backgroundColor = self.bottomView.backgroundColor = bgColor;
+
+    CGRect inputRect = self.dataReadingFrame.frame;
+    self.topView.frame = CGRectMake(0, 0, self.frame.size.width, inputRect.origin.y);
+    self.leftSideView.frame = CGRectMake(0, inputRect.origin.y, self.frameOffset, self.frameHeight);
+    self.rightSideView.frame = CGRectMake(inputRect.size.width + self.frameOffset, inputRect.origin.y, self.frameOffset, self.frameHeight);
+    self.bottomView.frame = CGRectMake(0, inputRect.origin.y + self.frameHeight, self.frame.size.width, self.frame.size.height - inputRect.origin.y - self.frameHeight);
+}
+
+
+- (void)layoutCornerViews {
+    UIView *frameView = self.dataReadingFrame;
+    CGFloat cornerSize = 20.f;
+    CGFloat cornerWidth = 2.f;
+    for (int i = 0; i < 8; i++) {
+        CGFloat x = 0.0;
+        CGFloat y = 0.0;
+        CGFloat width = 0.0;
+        CGFloat height = 0.0;
+        switch (i) {
+            case 0:
+                x = 0; y = 0; width = cornerWidth; height = cornerSize;
+                break;
+            case 1:
+                x = 0; y = 0; width = cornerSize; height = cornerWidth;
+                break;
+            case 2:
+                x = CGRectGetWidth(frameView.bounds) - cornerSize; y = 0; width = cornerSize; height = cornerWidth;
+                break;
+            case 3:
+                x = CGRectGetWidth(frameView.bounds) - cornerWidth; y = 0; width = cornerWidth; height = cornerSize;
+                break;
+            case 4:
+                x = CGRectGetWidth(frameView.bounds) - cornerWidth;
+                y = CGRectGetHeight(frameView.bounds) - cornerSize; width = cornerWidth; height = cornerSize;
+                break;
+            case 5:
+                x = CGRectGetWidth(frameView.bounds) - cornerSize;
+                y = CGRectGetHeight(frameView.bounds) - cornerWidth; width = cornerSize; height = cornerWidth;
+                break;
+            case 6:
+                x = 0; y = CGRectGetHeight(frameView.bounds) - cornerWidth; width = cornerSize; height = cornerWidth;
+                break;
+            case 7:
+                x = 0; y = CGRectGetHeight(frameView.bounds) - cornerSize; width = cornerWidth; height = cornerSize;
+                break;
+        }
+        UIView *cornerView = self.cornerViews[i];
+        cornerView.frame = CGRectMake(x, y, width, height);
+        cornerView.backgroundColor = self.frameColor;
+    }
+}
+
+
+@end


### PR DESCRIPTION
## Summary
- For an iPad app, device rotation is an ordinary thing. In our app, we support portrait and landscape. When the device rotates, the videoOrientation is not changed.

##  What is included in the PR:
- The captured content is not rotated as the device rotate, fixed.
- The frame of the scanner view is not updated when the device rotates, fixed.

## How did you test this change?

- use a physical device, both iPad and iPhone
