### PR TITLE
add Interleaved2of5 to supported barcode types on iOS

### DIFF
--- a/ios/ReactNativeCameraKit/CKCamera.m
+++ b/ios/ReactNativeCameraKit/CKCamera.m
@@ -1150,7 +1150,7 @@ didOutputMetadataObjects:(NSArray<__kindof AVMetadataObject *> *)metadataObjects
     NSArray *supportedBarcodeTypes = @[AVMetadataObjectTypeUPCECode,AVMetadataObjectTypeCode39Code,AVMetadataObjectTypeCode39Mod43Code,
                                        AVMetadataObjectTypeEAN13Code,AVMetadataObjectTypeEAN8Code, AVMetadataObjectTypeCode93Code,
                                        AVMetadataObjectTypeCode128Code, AVMetadataObjectTypePDF417Code, AVMetadataObjectTypeQRCode,
-                                       AVMetadataObjectTypeAztecCode, AVMetadataObjectTypeDataMatrixCode];
+                                       AVMetadataObjectTypeAztecCode, AVMetadataObjectTypeDataMatrixCode, AVMetadataObjectTypeInterleaved2of5Code];
     for (NSString* object in supportedBarcodeTypes) {
         if ([currentType isEqualToString:object]) {
             result = YES;


### PR DESCRIPTION
## Summary

For iOS it is currently not possible to scan Interleaved 2 of 5 (ITF) barcodes.

## How did you test this change?

1. Create an  Interleaved 2 of 5 barcode, e.g. on https://barcode.tec-it.com/en/Code25IL?data=1234567890
2. Scan barcode on iOS in example project, check whether it navigates to the result screen
