### PR TITLE
Bump metadata-extractor to 2.18.0 version to avoid 2.12.0 vulnerabilities

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.12.0'
+    implementation group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.18.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // CameraX core library using the camera2 implementation


### PR DESCRIPTION
## Summary

The library needs to update the metadata-extractor library to the latest version to avoid the high-security vulnerabilities of the 2.12.0 version.
https://security.snyk.io/package/maven/com.drewnoakes:metadata-extractor 