### PR TITLE
Fix #517. iOS simulator pictures are PNG instead of JPEG

### DIFF
--- a/ios/ReactNativeCameraKit/CKCamera.m
+++ b/ios/ReactNativeCameraKit/CKCamera.m
@@ -597,7 +597,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         if (self.mockPreview != nil) {
             UIImage *previewSnapshot = [self.mockPreview snapshotWithTimestamp:YES]; // Generate snapshot from main UI thread
             dispatch_async( self.sessionQueue, ^{ // write image async
-                [self writeCapturedImageData:UIImagePNGRepresentation(previewSnapshot) onSuccess:onSuccess onError:onError];
+                [self writeCapturedImageData:UIImageJPEGRepresentation(previewSnapshot, 0.85) onSuccess:onSuccess onError:onError];
             });
         } else {
             onError(@"Simulator image could not be captured from preview layer");


### PR DESCRIPTION
## Summary

Fix #517. iOS simulator pictures are PNG instead of JPEG

Use `UIImageJPEGRepresentation` instead of `UIImagePNGRepresentation`

## How did you test this change?

- Run on iOS simulator iPhone 14 Pro
- Take a picture
- Check the output file

### Before
<img src="https://github.com/teslamotors/react-native-camera-kit/assets/11665957/384f6b7f-085f-4fbb-8b49-f35baf01bc20" width="250px"/>

```
> file 16EA62A2-A2EC-4A45-B453-A9BA464EF668-70523-0000038BA79327B9.jpg
16EA62A2-A2EC-4A45-B453-A9BA464EF668-70523-0000038BA79327B9.jpg: PNG image data, 1179 x 1752, 8-bit/color RGBA, non-interlaced
```

### After
<img src="https://github.com/teslamotors/react-native-camera-kit/assets/11665957/073623c0-93cc-48ef-a57f-753e42fb35e3" width="250px" />

```
> file 70860A42-CC25-4FA3-AF27-F3DB397F6E2E-77443-0000039447870404.jpg
70860A42-CC25-4FA3-AF27-F3DB397F6E2E-77443-0000039447870404.jpg: JPEG image data, JFIF standard 1.01, aspect ratio, density 216x216, segment length 16, Exif Standard: [TIFF image data, big-endian, direntries=5, orientation=upper-left, xresolution=74, yresolution=82, resolutionunit=2], baseline, precision 8, 1179x1752, components 3
```