### PR TITLE
Fix: Correct onScale method signature in CKCamera.kt

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -180,11 +180,11 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
             orientationListener!!.enable()
 
             val scaleDetector =  ScaleGestureDetector(context, object: ScaleGestureDetector.SimpleOnScaleGestureListener() {
-                override fun onScale(detector: ScaleGestureDetector?): Boolean {
+                override fun onScale(detector: ScaleGestureDetector): Boolean {
                     if (zoomMode == "off") return true
                     val cameraControl = camera?.cameraControl ?: return true
                     val zoom = camera?.cameraInfo?.zoomState?.value?.zoomRatio ?: return true
-                    val scaleFactor = detector?.scaleFactor ?: return true
+                    val scaleFactor = detector.scaleFactor
                     val scale = zoom * scaleFactor
                     cameraControl.setZoomRatio(scale)
                     return true


### PR DESCRIPTION
## Summary

This PR fixes an issue with the `onScale` method override in `CKCamera.kt` file previously discussed [here](https://github.com/teslamotors/react-native-camera-kit/issues/535).

The 'onScale' method was attempting to override the interface method with a nullable parameter, causing a mismatch with the parent interface. This change corrects the method signature by changing the nullable parameter to non-nullable, aligning it with the interface and ensuring proper method overriding.

## How did you test this change?
- With this change, a new React Native app at `v0.72.0` will now build successfully on Android when the `compileSdkVersion` is set to `33`.
