### PR TITLE
Bugfix/ipad initial orientation

### DIFF
--- a/ios/ReactNativeCameraKit/CameraView.swift
+++ b/ios/ReactNativeCameraKit/CameraView.swift
@@ -93,7 +93,8 @@ class CameraView: UIView {
 
         scannerInterfaceView = ScannerInterfaceView(frameColor: .white, laserColor: .red)
         focusInterfaceView = FocusInterfaceView()
-
+        focusInterfaceView.update(focusMode: focusMode)
+        
         super.init(frame: frame)
 
         addSubview(camera.previewView)

--- a/ios/ReactNativeCameraKit/RealCamera.swift
+++ b/ios/ReactNativeCameraKit/RealCamera.swift
@@ -626,7 +626,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     private func setVideoOrientationToInterfaceOrientation() {
         var interfaceOrientation: UIInterfaceOrientation
         if #available(iOS 13.0, *) {
-            interfaceOrientation = self.previewView.window?.windowScene?.interfaceOrientation ?? .portrait
+            interfaceOrientation = UIApplication.shared.keyWindow!.windowScene!.interfaceOrientation
         } else {
             interfaceOrientation = UIApplication.shared.statusBarOrientation
         }

--- a/ios/ReactNativeCameraKit/RealCamera.swift
+++ b/ios/ReactNativeCameraKit/RealCamera.swift
@@ -626,7 +626,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     private func setVideoOrientationToInterfaceOrientation() {
         var interfaceOrientation: UIInterfaceOrientation
         if #available(iOS 13.0, *) {
-            interfaceOrientation = UIApplication.shared.keyWindow!.windowScene!.interfaceOrientation
+            interfaceOrientation = UIApplication.shared.keyWindow?.windowScene?.interfaceOrientation ?? .portrait
         } else {
             interfaceOrientation = UIApplication.shared.statusBarOrientation
         }


### PR DESCRIPTION
## Summary

1. The initial camera orientation is incorrect
2. focusMode should be on by default 

## How did you test this change?

on iPad