### PR TITLE
Fix linting error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,8 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 24
+        // noinspection ExpiredTargetSdkVersion
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 23
+        minSdkVersion = 24
         compileSdkVersion = 33
         targetSdkVersion = 33
         kotlin_version = '1.8.0'


### PR DESCRIPTION
- java.lang.Iterable#forEach requires minSdkVersion 24
- defaultConfig > targetSdkVersion 30 should be overridden by parent app, disable the error as it is Play Store specific

## Summary

Issue raised by #566

Running the linter on example project
```shell
./example/android/gradlew lintDebug
```
raises 3 errors on the library itself

- `java.lang.Iterable#forEach` requires minSdkVersion 24
  - in `rectBounds.forEach`
  - in `barcodes.forEach`
- `targetSdkVersion` must be higher than 31 for the Google Play Store

## Fix

- Bump `minSdkVersion` from 23 to 24
- Silent `ExpiredTargetSdkVersion` in the library because the parent app is setting their own. As it is a Google Play Store, someone using it on a private store would be fine
  - Is it needed to specify it at all on the library? Not sure

## How did you test this change?

No more linting error. It shouldn't impact the project as `minSdkVersion` doesn't do much.