### PR TITLE
Fix: Correct onScale method signature in CKCamera.kt (again)

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -185,14 +185,14 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
             orientationListener!!.enable()
 
             val scaleDetector =  ScaleGestureDetector(context, object: ScaleGestureDetector.SimpleOnScaleGestureListener() {
-                override fun onScaleBegin(detector: ScaleGestureDetector?): Boolean {
+                override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
                     val cameraZoom = camera?.cameraInfo?.zoomState?.value?.zoomRatio ?: return false
                     detector ?: return false
                     zoomStartedAt = cameraZoom
                     pinchGestureStartedAt = detector.currentSpan
                     return true
                 }
-                override fun onScale(detector: ScaleGestureDetector?): Boolean {
+                override fun onScale(detector: ScaleGestureDetector): Boolean {
                     if (zoomMode == "off") return true
                     if (detector == null) return true
                     val videoDevice = camera ?: return true


### PR DESCRIPTION
## Summary

#559 seems to have broken a change in #551, regarding override types. This restores the fix. The app was not able to build for React Native 0.72 without this change as the signatures are different.