### PR TITLE
Update build target to iOS 11

### DIFF
--- a/ReactNativeCameraKit.podspec
+++ b/ReactNativeCameraKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = "CameraKit"
   s.homepage     = "https://github.com/teslamotors/react-native-camera-kit"
-  s.platform     = :ios, "10.0"
+  s.platform     = :ios, "11.0"
 
   s.source       = { :git => "https://github.com/teslamotors/react-native-camera-kit.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"


### PR DESCRIPTION
## Summary

Resolves #602 by increasing the target build version to 11.0

## How did you test this change?

Tested by successfully building against React Native 0.71.12 on iOS