### PR TITLE
Add namespace to build.gradle for AGP > 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace "com.rncamerakit"
+    }
+
     compileSdkVersion 31
     defaultConfig {
         minSdkVersion 24


### PR DESCRIPTION
React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. See https://github.com/react-native-community/discussions-and-proposals/issues/671.

This will require all the libraries to specify a namespace in their build.gradle file. See AGP release notes https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl

