### PR TITLE
Fix #614. "onError" method needs to be declared

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCameraManager.kt
+++ b/android/src/main/java/com/rncamerakit/CKCameraManager.kt
@@ -47,7 +47,8 @@ class CKCameraManager : SimpleViewManager<CKCamera>() {
                 "onOrientationChange", MapBuilder.of("registrationName", "onOrientationChange"),
                 "onReadCode", MapBuilder.of("registrationName", "onReadCode"),
                 "onPictureTaken", MapBuilder.of("registrationName", "onPictureTaken"),
-                "onZoom", MapBuilder.of("registrationName", "onZoom")
+                "onZoom", MapBuilder.of("registrationName", "onZoom"),
+                "onError", MapBuilder.of("registrationName", "onError")
         )
     }
 


### PR DESCRIPTION
## Summary

Fix the error `Unsupported top level event type "onError" dispatched, js engine: hermes`, raised by #614 

When Android can't access the camera, it throws an error.
On v13 we were logging the error. On v14 we are forwarding it to the app
https://github.com/teslamotors/react-native-camera-kit/commit/73bd920ca46bdaa16c8254820728c50c900c682e

While doing it, we forgot to declare the method. Hence hermes raises an error for method unknown.

## Fix

Declare the method "onError"

## How did you test this change?

On an emulator without camera, it doesn't raise the error anymore.

And if "onError" is added on the application
```typescript
<Camera
  onError={(e) => console.log('error', e.nativeEvent)}
```
It does forward it.
```
 LOG  Running "CameraKitExample" with {"rootTag":11}
 LOG  error {"errorMessage": "Provided camera selector unable to resolve a camera for the given use case"}
```