### PR TITLE
Fix barcode screen top button size

### DIFF
--- a/example/src/BarcodeScreenExample.tsx
+++ b/example/src/BarcodeScreenExample.tsx
@@ -94,16 +94,17 @@ const BarcodeExample = ({ onBack }: { onBack: () => void }) => {
       <SafeAreaView style={styles.topButtons}>
         {flashData.image && (
           <TouchableOpacity style={styles.topButton} onPress={onSetFlash}>
-            <Image source={flashData.image} resizeMode="contain" />
+            <Image style={styles.topButtonImg} source={flashData.image} resizeMode="contain" />
           </TouchableOpacity>
         )}
 
         <TouchableOpacity style={styles.topButton} onPress={onSwitchCameraPressed}>
-          <Image source={require('../images/cameraFlipIcon.png')} resizeMode="contain" />
+          <Image style={styles.topButtonImg} source={require('../images/cameraFlipIcon.png')} resizeMode="contain" />
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.topButton} onPress={onSetTorch}>
           <Image
+            style={styles.topButtonImg}
             source={torchMode ? require('../images/torchOn.png') : require('../images/torchOff.png')}
             resizeMode="contain"
           />
@@ -199,7 +200,17 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   topButton: {
-    padding: 10,
+    backgroundColor: '#222',
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  topButtonImg: {
+    margin: 10,
+    width: 24,
+    height: 24,
   },
 
   cameraContainer: {


### PR DESCRIPTION
## Summary

Buttons on top of the barcode scanner are looking bad

![Screenshot 2023-12-21 at 2 36 05 PM](https://github.com/teslamotors/react-native-camera-kit/assets/11665957/49a2bcde-85d2-4fc0-945e-de4f99e026c5)

Reuse the same code we have on the camera screen

![Screenshot 2023-12-21 at 2 37 11 PM](https://github.com/teslamotors/react-native-camera-kit/assets/11665957/35b95f60-9219-42cc-88c7-3824b47cc746)


## How did you test this change?

Tested on iOS simulator 17 & Android emulator 32