### PR TITLE
Add namespace required by newer Gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.rncamerakit"
     compileSdkVersion 31
     defaultConfig {
         minSdkVersion 24


### PR DESCRIPTION
## Summary

While testing to update the example app to a newer ReactNative/Gradle version (for #589), I noticed Gradle requires a namespace to be defined.

Updating the example app will be done in another PR as it requires more testing, but adding the namespace could unblock some that are using it with a newer Gradle versions

There is a warning saying we can remove it from `AndroidManifest.xml`, but I wonder if that could break for users having a very old stack
> package="com.rncamerakit" found in source AndroidManifest.xml: react-native-camera-kit/android/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace

## How did you test this change?

The example app runs, shouldn't have any impact on the logic