### PR TITLE
Return height/width of capture on iOS

### DIFF
--- a/ios/ReactNativeCameraKit/CameraProtocol.swift
+++ b/ios/ReactNativeCameraKit/CameraProtocol.swift
@@ -28,6 +28,6 @@ protocol CameraProtocol: AnyObject, FocusInterfaceViewDelegate {
     func update(scannerFrameSize: CGRect?)
 
     func capturePicture(onWillCapture: @escaping () -> Void,
-                        onSuccess: @escaping (_ imageData: Data, _ thumbnailData: Data?) -> (),
+                        onSuccess: @escaping (_ imageData: Data, _ thumbnailData: Data?, _ dimensions: CMVideoDimensions) -> (),
                         onError: @escaping (_ message: String) -> ())
 }

--- a/ios/ReactNativeCameraKit/CameraView.swift
+++ b/ios/ReactNativeCameraKit/CameraView.swift
@@ -242,9 +242,13 @@ class CameraView: UIView {
                     self?.camera.previewView.alpha = 1
                 })
             }
-        }, onSuccess: { [weak self] imageData, thumbnailData in
+        }, onSuccess: { [weak self] imageData, thumbnailData, dimensions in
             DispatchQueue.global(qos: .default).async {
-                self?.writeCaptured(imageData: imageData, thumbnailData: thumbnailData, onSuccess: onSuccess, onError: onError)
+                self?.writeCaptured(imageData: imageData,
+                                    thumbnailData: thumbnailData,
+                                    dimensions: dimensions,
+                                    onSuccess: onSuccess,
+                                    onError: onError)
 
                 self?.focusInterfaceView.resetFocus()
             }
@@ -289,6 +293,7 @@ class CameraView: UIView {
 
     private func writeCaptured(imageData: Data,
                                thumbnailData: Data?,
+                               dimensions: CMVideoDimensions,
                                onSuccess: @escaping (_ imageObject: [String: Any]) -> (),
                                onError: @escaping (_ error: String) -> ()) {
         do {
@@ -298,7 +303,9 @@ class CameraView: UIView {
                 "size": imageData.count,
                 "uri": temporaryImageFileURL.description,
                 "name": temporaryImageFileURL.lastPathComponent,
-                "thumb": ""
+                "thumb": "",
+                "height": dimensions.height,
+                "width": dimensions.width
             ])
         } catch {
             let errorMessage = "Error occurred while writing image data to a temporary file: \(error)"

--- a/ios/ReactNativeCameraKit/PhotoCaptureDelegate.swift
+++ b/ios/ReactNativeCameraKit/PhotoCaptureDelegate.swift
@@ -12,12 +12,12 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
     private(set) var requestedPhotoSettings: AVCapturePhotoSettings
 
     private let onWillCapture: () -> Void
-    private let onCaptureSuccess: (_ uniqueID: Int64, _ imageData: Data, _ thumbnailData: Data?) -> Void
+    private let onCaptureSuccess: (_ uniqueID: Int64, _ imageData: Data, _ thumbnailData: Data?, _ dimensions: CMVideoDimensions) -> Void
     private let onCaptureError: (_ uniqueID: Int64, _ message: String) -> Void
 
     init(with requestedPhotoSettings: AVCapturePhotoSettings,
          onWillCapture: @escaping () -> Void,
-         onCaptureSuccess: @escaping (_ uniqueID: Int64, _ imageData: Data, _ thumbnailData: Data?) -> Void,
+         onCaptureSuccess: @escaping (_ uniqueID: Int64, _ imageData: Data, _ thumbnailData: Data?, _ dimensions: CMVideoDimensions) -> Void,
          onCaptureError: @escaping (_ uniqueID: Int64, _ errorMessage: String) -> Void) {
         self.requestedPhotoSettings = requestedPhotoSettings
         self.onWillCapture = onWillCapture
@@ -50,6 +50,6 @@ class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
             thumbnailData = uiImage.jpegData(compressionQuality: 0.7)
         }
 
-        onCaptureSuccess(requestedPhotoSettings.uniqueID, imageData, thumbnailData)
+        onCaptureSuccess(requestedPhotoSettings.uniqueID, imageData, thumbnailData, photo.resolvedSettings.photoDimensions)
     }
 }

--- a/ios/ReactNativeCameraKit/RealCamera.swift
+++ b/ios/ReactNativeCameraKit/RealCamera.swift
@@ -292,7 +292,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     }
 
     func capturePicture(onWillCapture: @escaping () -> Void,
-                        onSuccess: @escaping (_ imageData: Data, _ thumbnailData: Data?) -> Void,
+                        onSuccess: @escaping (_ imageData: Data, _ thumbnailData: Data?, _ dimensions: CMVideoDimensions) -> Void,
                         onError: @escaping (_ message: String) -> Void) {
         /*
          Retrieve the video preview layer's video orientation on the main queue before
@@ -317,10 +317,10 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
                 let photoCaptureDelegate = PhotoCaptureDelegate(
                     with: settings,
                     onWillCapture: onWillCapture,
-                    onCaptureSuccess: { uniqueID, imageData, thumbnailData in
+                    onCaptureSuccess: { uniqueID, imageData, thumbnailData, dimensions in
                         self.inProgressPhotoCaptureDelegates[uniqueID] = nil
                         
-                        onSuccess(imageData, thumbnailData)
+                        onSuccess(imageData, thumbnailData, dimensions)
                     },
                     onCaptureError: { uniqueID, errorMessage in
                         self.inProgressPhotoCaptureDelegates[uniqueID] = nil

--- a/ios/ReactNativeCameraKit/SimulatorCamera.swift
+++ b/ios/ReactNativeCameraKit/SimulatorCamera.swift
@@ -169,7 +169,7 @@ class SimulatorCamera: CameraProtocol {
     func update(scannerFrameSize: CGRect?) {}
 
     func capturePicture(onWillCapture: @escaping () -> Void,
-                        onSuccess: @escaping (_ imageData: Data, _ thumbnailData: Data?) -> (),
+                        onSuccess: @escaping (_ imageData: Data, _ thumbnailData: Data?, _ dimensions: CMVideoDimensions) -> (),
                         onError: @escaping (_ message: String) -> ()) {
         onWillCapture()
 
@@ -180,7 +180,7 @@ class SimulatorCamera: CameraProtocol {
             // Then switch to background thread
             DispatchQueue.global(qos: .default).async {
                 if let imageData = previewSnapshot?.jpegData(compressionQuality: 0.85) {
-                    onSuccess(imageData, nil)
+                    onSuccess(imageData, nil, CMVideoDimensions(width: 480, height: 640))
                 } else {
                     onError("Failed to convert snapshot to JPEG data")
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,11 +14,11 @@ export type ZoomMode = 'on' | 'off';
 export type CaptureData = {
   uri: string;
   name: string;
+  height: number;
+  width: number;
   // Android only
   id?: string;
   path?: string;
-  height?: number;
-  width?: number;
   // iOS only
   size?: number;
 };


### PR DESCRIPTION
## Summary

<!--
  1. Explain the **motivation** for making this change.
     What existing problem does the pull request solve?
  2. If you are fixing a bug, make sure there is an open ticket for it
-->
Return height/width of capture on iOS to be consistent with Android

Issue raised #641

## How did you test this change?

<!--
  1. Test your finished branch/PR on iOS and Android.
     Demonstrate the code is solid with screen shots of both platforms.
  If you leave this empty, your PR will very likely be closed.
-->

Built example & ran on device > camera > take a picture

It printed the expected values
```
'image', {
  uri: 'file:///var/mobile/Containers/Data/Application...',
  name: '09C6A457....jpg',
  size: 1886367,
  thumb: '',
  height: 3024,
  width: 4032
 }
```