### PR TITLE
Update Android Kotlin documentation for RN0.73+

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd ios && pod install && cd ..
 ```
 
 Android:
-[Add Kotlin to your project](./docs/kotlin.md)
+[Review your Kotlin configuration](./docs/kotlin.md) to ensure it's compatible with this library.
 
 ## Permissions
 

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -2,14 +2,16 @@
 
 1. Open and edit android/build.gradle
 
-Add the `kotlin_version` to `buildscript.ext`
+Add the `kotlin_version` to `buildscript.ext`. If you are using React Native `0.73` or higher, you should already have a variable called `kotlinVersion` defined inside of here, so remember you can reference this instead of repeating the version number twice:
 
 ```
 buildscript {
-  ext {
+    ext {
         ...
-        kotlin_version = '1.7.20'
-  }
+        kotlinVersion = '1.7.20' // Variable now included for React Native core
+        kotlin_version = kotlinVersion // Used by react-native-camera-kit
+    }
+}
 ```
 
 Add `google()` to the `buildscript.repositories` and `allprojects.repositories`


### PR DESCRIPTION
## Summary

Some minor changes made to the README and Kotlin document to reflect that fact that React Native 0.73+ now has Kotlin included by default, and that despite this, some minor modifications to the `android/build.gradle` will still be required. The changes also reminds developers that they can use the existing variable instead of defining a specific Kotlin version twice.

## How did you test this change?

N/A
