### PR TITLE
add mac catalyst support

### DIFF
--- a/ios/ReactNativeCameraKit/CameraManager.swift
+++ b/ios/ReactNativeCameraKit/CameraManager.swift
@@ -28,15 +28,35 @@ import Foundation
 
     @objc public static func checkDeviceCameraAuthorizationStatus(_ resolve: @escaping RCTPromiseResolveBlock,
                                                     reject: @escaping RCTPromiseRejectBlock) {
-        switch AVCaptureDevice.authorizationStatus(for: .video) {
-        case .authorized: resolve(true)
-        case .notDetermined: resolve(-1)
-        default: resolve(false)
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 14.0, *) {
+            switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized: resolve(true)
+            case .notDetermined: resolve(-1)
+            default: resolve(false)
+            }
+        } else {
+            resolve(false)
         }
+        #else
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized: resolve(true)
+            case .notDetermined: resolve(-1)
+            default: resolve(false)
+        }
+        #endif
     }
 
     @objc public static func requestDeviceCameraAuthorization(_ resolve: @escaping RCTPromiseResolveBlock,
                                                 reject: @escaping RCTPromiseRejectBlock) {
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 14.0, *) {
+            AVCaptureDevice.requestAccess(for: .video, completionHandler: { resolve($0) })
+        } else {
+            resolve(false)
+        }
+        #else
         AVCaptureDevice.requestAccess(for: .video, completionHandler: { resolve($0) })
+        #endif
     }
 }

--- a/ios/ReactNativeCameraKit/RealCamera.swift
+++ b/ios/ReactNativeCameraKit/RealCamera.swift
@@ -55,6 +55,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
 
     // MARK: - Lifecycle
     
+    #if !targetEnvironment(macCatalyst)
     override init() {
         super.init()
 
@@ -68,6 +69,12 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
                                                queue: nil,
                                                using: { _ in self.setVideoOrientationToInterfaceOrientation() })
     }
+    #else
+    override init() {
+        super.init()
+        // Mac Catalyst doesn't support device orientation notifications
+    }
+    #endif
     
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
@@ -82,11 +89,13 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
             }
         }
 
+        #if !targetEnvironment(macCatalyst)
         motionManager?.stopAccelerometerUpdates()
 
         NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: UIDevice.current)
 
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
+        #endif
     }
 
     deinit {
@@ -591,6 +600,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     // MARK: - Private device orientation from accelerometer
 
     private func initializeMotionManager() {
+        #if !targetEnvironment(macCatalyst)
         motionManager = CMMotionManager()
         motionManager?.accelerometerUpdateInterval = 0.2
         motionManager?.gyroUpdateInterval = 0.2
@@ -612,6 +622,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
             self.deviceOrientation = newOrientation
             self.onOrientationChange?(["orientation": Orientation.init(from: newOrientation)!.rawValue])
         })
+        #endif
     }
 
     private func deviceOrientation(from acceleration: CMAcceleration) -> UIDeviceOrientation? {
@@ -678,6 +689,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     }
 
     private func setVideoOrientationToInterfaceOrientation() {
+        #if !targetEnvironment(macCatalyst)
         var interfaceOrientation: UIInterfaceOrientation
         if #available(iOS 13.0, *) {
             interfaceOrientation = self.previewView.window?.windowScene?.interfaceOrientation ?? .portrait
@@ -685,6 +697,10 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
             interfaceOrientation = UIApplication.shared.statusBarOrientation
         }
         self.cameraPreview.previewLayer.connection?.videoOrientation = self.videoOrientation(from: interfaceOrientation)
+        #else
+        // Mac Catalyst always uses landscape orientation
+        self.cameraPreview.previewLayer.connection?.videoOrientation = .landscapeRight
+        #endif
     }
 
     private func sessionRuntimeError(notification: Notification) {


### PR DESCRIPTION
## Summary

Mac Catalyst used to work on v13. it broke on v14.

## How did you test this change?

Using my Mac (m2 pro). Launched the camera and scanned a QR code. detected  and value passed successfully. 