### PR TITLE
Fixes for catalyst

### DIFF
--- a/ios/ReactNativeCameraKit/CameraManager.swift
+++ b/ios/ReactNativeCameraKit/CameraManager.swift
@@ -28,15 +28,35 @@ import Foundation
 
     @objc public static func checkDeviceCameraAuthorizationStatus(_ resolve: @escaping RCTPromiseResolveBlock,
                                                     reject: @escaping RCTPromiseRejectBlock) {
-        switch AVCaptureDevice.authorizationStatus(for: .video) {
-        case .authorized: resolve(true)
-        case .notDetermined: resolve(-1)
-        default: resolve(false)
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 14.0, *) {
+            switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized: resolve(true)
+            case .notDetermined: resolve(-1)
+            default: resolve(false)
+            }
+        } else {
+            resolve(false)
         }
+        #else
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized: resolve(true)
+            case .notDetermined: resolve(-1)
+            default: resolve(false)
+        }
+        #endif
     }
 
     @objc public static func requestDeviceCameraAuthorization(_ resolve: @escaping RCTPromiseResolveBlock,
                                                 reject: @escaping RCTPromiseRejectBlock) {
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 14.0, *) {
+            AVCaptureDevice.requestAccess(for: .video, completionHandler: { resolve($0) })
+        } else {
+            resolve(false)
+        }
+        #else
         AVCaptureDevice.requestAccess(for: .video, completionHandler: { resolve($0) })
+        #endif
     }
 }

--- a/ios/ReactNativeCameraKit/CameraView.swift
+++ b/ios/ReactNativeCameraKit/CameraView.swift
@@ -80,7 +80,12 @@ public class CameraView: UIView {
     private func setupCamera() {
         if hasPropBeenSetup && hasPermissionBeenGranted && !hasCameraBeenSetup {
             hasCameraBeenSetup = true
+            #if targetEnvironment(macCatalyst)
+            // Force front camera on Mac Catalyst during initial setup
+            camera.setup(cameraType: .front, supportedBarcodeType: scanBarcode && onReadCode != nil ? supportedBarcodeType : [])
+            #else
             camera.setup(cameraType: cameraType, supportedBarcodeType: scanBarcode && onReadCode != nil ? supportedBarcodeType : [])
+            #endif
         }
     }
 
@@ -124,6 +129,7 @@ public class CameraView: UIView {
     }
     
     private func configureHardwareInteraction() {
+        #if !targetEnvironment(macCatalyst)
         // Create a new capture event interaction with a handler that captures a photo.
         if #available(iOS 17.2, *) {
             let interaction = AVCaptureEventInteraction { event in
@@ -138,6 +144,7 @@ public class CameraView: UIView {
             self.addInteraction(interaction)
             eventInteraction = interaction
         }
+        #endif
     }
 
     override public func removeFromSuperview() {
@@ -155,7 +162,10 @@ public class CameraView: UIView {
     
     @objc public func updateSubviewsBounds(_ frame: CGRect) {
         camera.previewView.frame = bounds
-
+        #if targetEnvironment(macCatalyst)
+        // Do not apply any transform on Mac Catalyst
+        // (macCatalyst orientation is managed by AVFoundation as set in RealCamera)
+        #endif
         scannerInterfaceView.frame = bounds
         // If frame size changes, we have to update the scanner
         camera.update(scannerFrameSize: showFrame ? scannerInterfaceView.frameSize : nil)
@@ -177,7 +187,12 @@ public class CameraView: UIView {
 
         // Camera settings
         if changedProps.contains("cameraType") {
+            #if targetEnvironment(macCatalyst)
+            // Force front camera on Mac Catalyst regardless of what's passed
+            camera.update(cameraType: .front)
+            #else
             camera.update(cameraType: cameraType)
+            #endif
         }
         if changedProps.contains("flashMode") {
             camera.update(flashMode: flashMode)
@@ -314,6 +329,26 @@ public class CameraView: UIView {
     }
 
     private func handleCameraPermission() {
+        #if targetEnvironment(macCatalyst)
+        // On macOS, camera permissions are handled differently
+        if #available(macCatalyst 14.0, *) {
+            switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized:
+                hasPermissionBeenGranted = true
+            case .notDetermined:
+                AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                    if granted {
+                        DispatchQueue.main.async {
+                            self?.hasPermissionBeenGranted = true
+                        }
+                    }
+                }
+            default:
+                break
+            }
+        }
+        #else
+        // iOS permission handling
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .authorized:
             // The user has previously granted access to the camera.
@@ -329,6 +364,7 @@ public class CameraView: UIView {
             // The user has previously denied access.
             break
         }
+        #endif
     }
 
     private func writeCaptured(imageData: Data,

--- a/ios/ReactNativeCameraKit/RealCamera.swift
+++ b/ios/ReactNativeCameraKit/RealCamera.swift
@@ -55,6 +55,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
 
     // MARK: - Lifecycle
     
+    #if !targetEnvironment(macCatalyst)
     override init() {
         super.init()
 
@@ -68,6 +69,12 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
                                                queue: nil,
                                                using: { _ in self.setVideoOrientationToInterfaceOrientation() })
     }
+    #else
+    override init() {
+        super.init()
+        // Mac Catalyst doesn't support device orientation notifications
+    }
+    #endif
     
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
@@ -82,11 +89,13 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
             }
         }
 
+        #if !targetEnvironment(macCatalyst)
         motionManager?.stopAccelerometerUpdates()
 
         NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: UIDevice.current)
 
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
+        #endif
     }
 
     deinit {
@@ -123,6 +132,12 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
            DispatchQueue.main.async {
                self.setVideoOrientationToInterfaceOrientation()
            }
+
+           #if targetEnvironment(macCatalyst)
+           if let connection = self.cameraPreview.previewLayer.connection {
+               connection.videoOrientation = .portrait
+           }
+           #endif
         }
     }
 
@@ -591,6 +606,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     // MARK: - Private device orientation from accelerometer
 
     private func initializeMotionManager() {
+        #if !targetEnvironment(macCatalyst)
         motionManager = CMMotionManager()
         motionManager?.accelerometerUpdateInterval = 0.2
         motionManager?.gyroUpdateInterval = 0.2
@@ -612,6 +628,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
             self.deviceOrientation = newOrientation
             self.onOrientationChange?(["orientation": Orientation.init(from: newOrientation)!.rawValue])
         })
+        #endif
     }
 
     private func deviceOrientation(from acceleration: CMAcceleration) -> UIDeviceOrientation? {
@@ -678,6 +695,14 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     }
 
     private func setVideoOrientationToInterfaceOrientation() {
+        #if targetEnvironment(macCatalyst)
+        if let connection = self.cameraPreview.previewLayer.connection {
+            connection.automaticallyAdjustsVideoMirroring = false  // Disable automatic mirroring
+            connection.videoOrientation = .portrait         // Force portrait
+            connection.isVideoMirrored = false                      // Ensure no mirroring
+        }
+        self.cameraPreview.previewLayer.setAffineTransform(.identity)
+        #else
         var interfaceOrientation: UIInterfaceOrientation
         if #available(iOS 13.0, *) {
             interfaceOrientation = self.previewView.window?.windowScene?.interfaceOrientation ?? .portrait
@@ -685,6 +710,7 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
             interfaceOrientation = UIApplication.shared.statusBarOrientation
         }
         self.cameraPreview.previewLayer.connection?.videoOrientation = self.videoOrientation(from: interfaceOrientation)
+        #endif
     }
 
     private func sessionRuntimeError(notification: Notification) {

--- a/ios/ReactNativeCameraKit/RealCamera.swift
+++ b/ios/ReactNativeCameraKit/RealCamera.swift
@@ -54,7 +54,6 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
     private var inProgressPhotoCaptureDelegates = [Int64: PhotoCaptureDelegate]()
 
     // MARK: - Lifecycle
-    
     #if !targetEnvironment(macCatalyst)
     override init() {
         super.init()
@@ -75,8 +74,8 @@ class RealCamera: NSObject, CameraProtocol, AVCaptureMetadataOutputObjectsDelega
         // Mac Catalyst doesn't support device orientation notifications
     }
     #endif
-    
-    @available(*, unavailable)
+
+@available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }


### PR DESCRIPTION
## Summary

Bug fixes for recent Mac Catalyst support. Camera View was flipped by default. Should be portrait.

## How did you test this change?

By testing it during my development  of BlueWallet scan qr feature (https://github.com/BlueWallet/BlueWallet/pull/7651) 