### PR TITLE
Use the view finder's dimensions instead of the whole screen's to determine the photo aspect ratio

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -282,12 +282,13 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
 
     private fun bindCameraUseCases() {
         if (viewFinder.display == null) return
-        // Get screen metrics used to setup camera for full screen resolution
-        val metrics = DisplayMetrics().also { viewFinder.display.getRealMetrics(it) }
-        Log.d(TAG, "Screen metrics: ${metrics.widthPixels} x ${metrics.heightPixels}")
 
-        val screenAspectRatio = aspectRatio(metrics.widthPixels, metrics.heightPixels)
-        Log.d(TAG, "Preview aspect ratio: $screenAspectRatio")
+        val previewWidth = viewFinder.getWidth();
+        val previewHeight = viewFinder.getHeight();
+        Log.d(TAG, "Preview dimensions: $previewWidth x $previewHeight")
+
+        val previewAspectRatio = aspectRatio(previewWidth, previewHeight)
+        Log.d(TAG, "Preview aspect ratio: $previewAspectRatio")
 
         val rotation = viewFinder.display.rotation
 
@@ -301,7 +302,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
         // Preview
         preview = Preview.Builder()
                 // We request aspect ratio but no resolution
-                .setTargetAspectRatio(screenAspectRatio)
+                .setTargetAspectRatio(previewAspectRatio)
                 // Set initial target rotation
                 .setTargetRotation(rotation)
                 .build()
@@ -311,7 +312,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
             .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
             // We request aspect ratio but no resolution to match preview config, but letting
             // CameraX optimize for whatever specific resolution best fits our use cases
-            .setTargetAspectRatio(screenAspectRatio)
+            .setTargetAspectRatio(previewAspectRatio)
             // Set initial target rotation, we will have to call this again if rotation changes
             // during the lifecycle of this use case
             .setTargetRotation(rotation)
@@ -320,7 +321,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
         // ImageAnalysis
         imageAnalyzer = ImageAnalysis.Builder()
             .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-            .setTargetAspectRatio(screenAspectRatio)
+            .setTargetAspectRatio(previewAspectRatio)
             .build()
 
         val useCases = mutableListOf(preview, imageCapture)


### PR DESCRIPTION
## Summary

Currently the aspect ratio of the photo is determined by the size of the device's screen. This assumes that the preview / view finder covers the whole screen, but that is not necessarily the case - for example in our use case, in portrait mode we have an app header above and UI elements below the view finder, intentionally resulting in a view finder with a 4:3 aspect ratio. In this case, a photo captured at 16:9 would not match what was displayed in the view finder. It seems to me that the aspect ratio of the captured photo should be driven by the view finder dimensions rather than the device's screen size.

This seems similar to the issue logged in #576 but not quite the same.

## How did you test this change?

Tested on a few different Android devices.

4:3 view finder:
<img src="https://github.com/user-attachments/assets/36f17c06-efde-40cd-84e3-7cadb6a28d49" width=200 />

16:9 view finder:
<img src="https://github.com/user-attachments/assets/e3d88e45-0411-46ad-82ab-9abd13d39939" width=200 />