### PR TITLE
Fix checking focusMode instead of zoomMode

### DIFF
--- a/ios/ReactNativeCameraKit/CKCameraViewComponentView.mm
+++ b/ios/ReactNativeCameraKit/CKCameraViewComponentView.mm
@@ -224,7 +224,7 @@ static id CKConvertFollyDynamicToId(const folly::dynamic &dyn)
     }
     id zoomMode = CKConvertFollyDynamicToId(newProps.zoomMode);
     if (zoomMode != nil) {
-        _view.zoomMode = [focusMode isEqualToString:@"on"] ? CKZoomModeOn : CKZoomModeOff;
+        _view.zoomMode = [zoomMode isEqualToString:@"on"] ? CKZoomModeOn : CKZoomModeOff;
         [changedProps addObject:@"zoomMode"];
     }
     id zoom = CKConvertFollyDynamicToId(newProps.zoom);


### PR DESCRIPTION
## Summary

zoomMode is checking focusMode instead of zoomMode, making it copy focusMode state instead of being independent

## How did you test this change?

By running locally