### PR TITLE
Fix fabric layout issues in iOS on fresh React Native v0.80.0 

### DIFF
--- a/ios/ReactNativeCameraKit/CameraView.swift
+++ b/ios/ReactNativeCameraKit/CameraView.swift
@@ -91,6 +91,17 @@ public class CameraView: UIView {
         }
     }
 
+    // Use constraints for FABRIC 0.80.0
+    private func addFullSizeSubview(_ subview: UIView) {
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(subview)
+        NSLayoutConstraint.activate([
+            subview.topAnchor.constraint(equalTo: self.topAnchor),
+            subview.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            subview.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            subview.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
+    }
 
     // MARK: Lifecycle
 
@@ -123,6 +134,11 @@ public class CameraView: UIView {
         scannerInterfaceView.isHidden = true
 
         addSubview(focusInterfaceView)
+
+        addFullSizeSubview(camera.previewView)
+        addFullSizeSubview(scannerInterfaceView)
+        addFullSizeSubview(focusInterfaceView)
+
         focusInterfaceView.delegate = camera
 
         handleCameraPermission()


### PR DESCRIPTION
## Summary

### Add constraints for all 

#### Motiviation

We at DigiCorp Labs are using this awesome camera library in our enterprise apps for code scanning.
During the update of one of our apps to React Native 0.80.0 the screen disappeared. It took us a while to figure out what was going on, but it seems that the new fabric renderer doesn't set the correct constraints and the developer has to do this now, otherwise we get a white screen just as described in the issue: https://github.com/teslamotors/react-native-camera-kit/issues/708. Note that this is definitely not a permission issue; we tested this a couple of times. The view simply doesn't have a layout set.

#### **What we changed in this PR**

* Introduced a helper that embeds each subview with full-height-and-width constraints:
https://github.com/SmartArray/react-native-camera-kit/blob/c70b91e38599799b574af5a0fca7967aee99b22c/ios/ReactNativeCameraKit/CameraView.swift#L98-105

* Applied this helper to camera preview, overlay, focus, and scanner views.

#### **Why It Was Required**

* Without explicit constraints, UIKit reported **ambiguous layout**, leading to views being present in the hierarchy; but never rendered
* React Native’s **Fabric architecture** expects native components to have well-defined layouts; otherwise they fail to mount and display correctly.
* This change ensures that each subview fills its parent unambiguously, stabilizing native view rendering under Fabric.
* Please note that constraining the view to the outer edges of the parent view (RCTView) seems to be the correct way of handling the layout, since the RCTView is still managed completely by React Native.
***


## How did you test this change?
- Physical Devices:
  - iPhone 12
  - iPhone 15 Pro
- Simulator

## Further testing
* We would like the creator of https://github.com/teslamotors/react-native-camera-kit/issues/708 to test whether this PR fixes the issues on their side too
* Android apps should be completely unaffected by this PR