### PR TITLE
Fixed issue #518 modified Camera.kt file 

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -575,7 +575,10 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
         val camera = camera ?: return
         when (mode) {
             "on" -> {
+                //pause camera preview to avoid flickering
+                preview?.setSurfaceProvider(null)
                 camera.cameraControl.enableTorch(true)
+                preview?.setSurfaceProvider(viewFinder.surfaceProvider)
             }
             "off" -> {
                 camera.cameraControl.enableTorch(false)


### PR DESCRIPTION
## Summary

<!--
   I've added react-native-camera-kit library in my project where I want to use camera for scanning qrcodes. I want to toggle torch while camera being on for flash purpose in low light scenarios. Library provides a prop name torchMode where we can pass 'on' and 'off' values, but it was only working for iOS and not for android. In android flash was just blinking and not staying on. This same issue has been observed by other people as well and there is a thread also for this https://github.com/teslamotors/react-native-camera-kit/issues/518.


## How did you test this change?

<!--
  I've tested this change in different android versions like 11, 13, 14, 15 and it is working fine in every one of them.
-->
