### PR TITLE
fix: memory leak introduced in 21f7601

### DIFF
--- a/ios/ReactNativeCameraKit/CameraView.swift
+++ b/ios/ReactNativeCameraKit/CameraView.swift
@@ -134,12 +134,12 @@ public class CameraView: UIView {
         #if !targetEnvironment(macCatalyst)
         // Create a new capture event interaction with a handler that captures a photo.
         if #available(iOS 17.2, *) {
-            let interaction = AVCaptureEventInteraction { event in
+            let interaction = AVCaptureEventInteraction { [weak self] event in
                 // Capture a photo on "press up" of a hardware button.
                 if event.phase == .began {
-                    self.onCaptureButtonPressIn?(nil)
+                    self?.onCaptureButtonPressIn?(nil)
                 } else if event.phase == .ended {
-                    self.onCaptureButtonPressOut?(nil)
+                    self?.onCaptureButtonPressOut?(nil)
                 }
             }
             // Add the interaction to the view controller's view.


### PR DESCRIPTION
## Issue

- Self is accessed within `AVCaptureEventInteraction` closure
- The `AVCaptureEventInteraction` is stored in eventInteraction class variable
- This creates a retain cycle

https://github.com/teslamotors/react-native-camera-kit/blob/21f760117b8865cb1865001cf14a728087162e8d/ios/ReactNativeCameraKit/CameraView.swift#L128-L135

## Solution

Use [weak self] to break the cycle

## How did you test this change?

- Launch App
- Open Camera 3 times

### Before
- Observe leak, 3 instances of CKCameraView because of the closure
![before](https://github.com/user-attachments/assets/9900c504-cf2c-472a-adca-394ce53ac824)

### After
- No leak, closure doesn't retain anything
![after](https://github.com/user-attachments/assets/03c9ed3a-5733-427f-b49f-5de94d0ff130)