### PR TITLE
fix: refact events to react

### DIFF
--- a/ios/ReactNativeCameraKit/CKCameraViewComponentView.h
+++ b/ios/ReactNativeCameraKit/CKCameraViewComponentView.h
@@ -1,3 +1,8 @@
+//
+//  CKCameraViewComponentView.h
+//  ReactNativeCameraKit
+//
+
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import <UIKit/UIKit.h>
@@ -8,6 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CKCameraViewComponentView : RCTViewComponentView
+- (facebook::react::SharedViewEventEmitter)eventEmitter;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/ReactNativeCameraKit/CameraEventEmitter.swift
+++ b/ios/ReactNativeCameraKit/CameraEventEmitter.swift
@@ -1,0 +1,55 @@
+//
+//  CameraEventEmitter.swift
+//  ReactNativeCameraKit
+//
+
+@objc public protocol CameraEventEmitter {
+    @objc func onReadCode(codeStringValue: String, codeFormat: String)
+    @objc func onOrientationChange(orientation: Int)
+    @objc func onZoom(zoom: Double)
+
+    @objc func onCaptureButtonPressIn()
+    @objc func onCaptureButtonPressOut()
+}
+
+class OldArchCameraEventEmitter: CameraEventEmitter {
+    var onReadCodeProp: RCTDirectEventBlock?
+    var onOrientationChangeProp: RCTDirectEventBlock?
+    var onZoomProp: RCTDirectEventBlock?
+    var onCaptureButtonPressInProp: RCTDirectEventBlock?
+    var onCaptureButtonPressOutProp: RCTDirectEventBlock?
+    
+    init(onReadCodeProp: RCTDirectEventBlock?,
+         onOrientationChangeProp: RCTDirectEventBlock?,
+         onZoomProp: RCTDirectEventBlock?,
+         onCaptureButtonPressInProp: RCTDirectEventBlock?,
+         onCaptureButtonPressOutProp: RCTDirectEventBlock?) {
+        self.onReadCodeProp = onReadCodeProp
+        self.onOrientationChangeProp = onOrientationChangeProp
+        self.onZoomProp = onZoomProp
+        self.onCaptureButtonPressInProp = onCaptureButtonPressInProp
+        self.onCaptureButtonPressOutProp = onCaptureButtonPressOutProp
+    }
+    
+    func onReadCode(codeStringValue: String, codeFormat: String) {
+        onReadCodeProp?(["codeStringValue": codeStringValue, "codeFormat": codeFormat])
+    }
+    
+    func onOrientationChange(orientation: Int) {
+        onOrientationChangeProp?(["orientation": orientation])
+    }
+    
+    func onZoom(zoom: Double) {
+        print("onZoom")
+        print(onZoomProp.debugDescription)
+        onZoomProp?(["zoom": zoom])
+    }
+    
+    func onCaptureButtonPressIn() {
+        onCaptureButtonPressInProp?(nil)
+    }
+    
+    func onCaptureButtonPressOut() {
+        onCaptureButtonPressOutProp?(nil)
+    }
+}

--- a/ios/ReactNativeCameraKit/CameraProtocol.swift
+++ b/ios/ReactNativeCameraKit/CameraProtocol.swift
@@ -11,11 +11,11 @@ protocol CameraProtocol: AnyObject, FocusInterfaceViewDelegate {
     func setup(cameraType: CameraType, supportedBarcodeType: [CodeFormat])
     func cameraRemovedFromSuperview()
 
+    func update(eventEmitter: CameraEventEmitter?)
+
     func update(torchMode: TorchMode)
     func update(flashMode: FlashMode)
     func update(cameraType: CameraType)
-    func update(onOrientationChange: RCTDirectEventBlock?)
-    func update(onZoom: RCTDirectEventBlock?)
     func update(zoom: Double?)
     func update(maxZoom: Double?)
     func update(resizeMode: ResizeMode)

--- a/ios/ReactNativeCameraKit/CameraView.swift
+++ b/ios/ReactNativeCameraKit/CameraView.swift
@@ -15,6 +15,13 @@ import AVKit
 public class CameraView: UIView {
     private let camera: CameraProtocol
 
+    // expose event native -> react
+    @objc public var eventEmitter: CameraEventEmitter? {
+        didSet {
+            camera.update(eventEmitter: eventEmitter)
+        }
+    }
+
     // Focus
     private let focusInterfaceView: FocusInterfaceView
 
@@ -44,25 +51,25 @@ public class CameraView: UIView {
     // scanner
     @objc public var scanBarcode = false
     @objc public var showFrame = false
-    @objc public var onReadCode: RCTDirectEventBlock?
     @objc public var scanThrottleDelay = 2000
     @objc public var frameColor: UIColor?
     @objc public var laserColor: UIColor?
     @objc public var barcodeFrameSize: NSDictionary?
-
     // other
-    @objc public var onOrientationChange: RCTDirectEventBlock?
-    @objc public var onZoom: RCTDirectEventBlock?
     @objc public var resetFocusTimeout = 0
     @objc public var resetFocusWhenMotionDetected = false
     @objc public var focusMode: FocusMode = .on
     @objc public var zoomMode: ZoomMode = .on
     @objc public var zoom: NSNumber?
     @objc public var maxZoom: NSNumber?
-
+    // callbacks (only defined for old architecture)
+    @objc public var onReadCode: RCTDirectEventBlock?
+    @objc public var onOrientationChange: RCTDirectEventBlock?
+    @objc public var onZoom: RCTDirectEventBlock?
     @objc public var onCaptureButtonPressIn: RCTDirectEventBlock?
     @objc public var onCaptureButtonPressOut: RCTDirectEventBlock?
     
+    // interaction on physical volume button
     var eventInteraction: Any? = nil
 
     // MARK: - Setup
@@ -84,13 +91,12 @@ public class CameraView: UIView {
             hasCameraBeenSetup = true
             #if targetEnvironment(macCatalyst)
             // Force front camera on Mac Catalyst during initial setup
-            camera.setup(cameraType: .front, supportedBarcodeType: scanBarcode && onReadCode != nil ? supportedBarcodeType : [])
+            camera.setup(cameraType: .front, supportedBarcodeType: scanBarcode ? supportedBarcodeType : [])
             #else
-            camera.setup(cameraType: cameraType, supportedBarcodeType: scanBarcode && onReadCode != nil ? supportedBarcodeType : [])
+            camera.setup(cameraType: cameraType, supportedBarcodeType: scanBarcode ? supportedBarcodeType : [])
             #endif
         }
     }
-
 
     // MARK: Lifecycle
 
@@ -134,16 +140,16 @@ public class CameraView: UIView {
         #if !targetEnvironment(macCatalyst)
         // Create a new capture event interaction with a handler that captures a photo.
         if #available(iOS 17.2, *) {
-            let interaction = AVCaptureEventInteraction { event in
+            let interaction = AVCaptureEventInteraction { [weak self] event in
                 // Capture a photo on "press up" of a hardware button.
                 if event.phase == .began {
-                    self.onCaptureButtonPressIn?(nil)
+                    self?.eventEmitter?.onCaptureButtonPressIn()
                 } else if event.phase == .ended {
-                    self.onCaptureButtonPressOut?(nil)
+                    self?.eventEmitter?.onCaptureButtonPressOut()
                 }
             }
             // Add the interaction to the view controller's view.
-            self.addInteraction(interaction)
+            addInteraction(interaction)
             eventInteraction = interaction
         }
         #endif
@@ -184,6 +190,18 @@ public class CameraView: UIView {
     override public func didSetProps(_ changedProps: [String]) {
         hasPropBeenSetup = true
 
+        // Initialized here for old architecture, initialized in CKCameraViewComponentView for new architecture
+        if (eventEmitter == nil) {
+            eventEmitter = OldArchCameraEventEmitter(
+                onReadCodeProp: onReadCode,
+                onOrientationChangeProp: onOrientationChange,
+                onZoomProp: onZoom,
+                onCaptureButtonPressInProp: onCaptureButtonPressIn,
+                onCaptureButtonPressOutProp: onCaptureButtonPressOut
+            )
+            camera.update(eventEmitter: eventEmitter)
+        }
+
         // Camera settings
         if changedProps.contains("cameraType") {
             #if targetEnvironment(macCatalyst)
@@ -201,14 +219,6 @@ public class CameraView: UIView {
         }
         if changedProps.contains("maxPhotoQualityPrioritization") {
             camera.update(maxPhotoQualityPrioritization: maxPhotoQualityPrioritization)
-        }
-
-        if changedProps.contains("onOrientationChange") {
-            camera.update(onOrientationChange: onOrientationChange)
-        }
-
-        if changedProps.contains("onZoom") {
-            camera.update(onZoom: onZoom)
         }
         
         if changedProps.contains("resizeMode") {
@@ -235,7 +245,7 @@ public class CameraView: UIView {
         }
 
         // Scanner
-        if changedProps.contains("scanBarcode") || changedProps.contains("onReadCode") {
+        if changedProps.contains("scanBarcode") || changedProps.contains("onReadCode") /* only old arch. */ {
             camera.isBarcodeScannerEnabled(scanBarcode,
                                            supportedBarcodeTypes: supportedBarcodeType,
                                            onBarcodeRead: { [weak self] (barcode, codeFormat) in
@@ -420,7 +430,7 @@ public class CameraView: UIView {
 
         lastBarcodeDetectedTime = now
 
-        onReadCode?(["codeStringValue": barcode,"codeFormat":codeFormat.rawValue])
+        eventEmitter?.onReadCode(codeStringValue: barcode, codeFormat: codeFormat.rawValue)
     }
 
     // MARK: - Gesture selectors

--- a/ios/ReactNativeCameraKit/NewArchCameraEventEmitter.h
+++ b/ios/ReactNativeCameraKit/NewArchCameraEventEmitter.h
@@ -1,0 +1,18 @@
+//
+//  NewArchCameraEventEmitter.h
+//  ReactNativeCameraKit
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+@class CKCameraViewComponentView;
+@protocol CameraEventEmitter;
+
+/* This unfortunately needs to be in ObjectiveC since it's using C++ implementation */
+@interface NewArchCameraEventEmitter : NSObject <CameraEventEmitter>
+
+- (instancetype)initWithCameraViewComponentView:(CKCameraViewComponentView *)viewComponentView;
+
+@end
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/ReactNativeCameraKit/NewArchCameraEventEmitter.mm
+++ b/ios/ReactNativeCameraKit/NewArchCameraEventEmitter.mm
@@ -1,0 +1,67 @@
+//
+//  NewArchCameraEventEmitter.mm
+//  ReactNativeCameraKit
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "NewArchCameraEventEmitter.h"
+
+#import "CKCameraViewComponentView.h"
+#import "ReactNativeCameraKit-Swift.h"
+#import <react/renderer/components/rncamerakit_specs/EventEmitters.h>
+
+@interface NewArchCameraEventEmitter () {
+    __weak CKCameraViewComponentView *_viewComponentView;
+}
+@end
+
+@implementation NewArchCameraEventEmitter
+
+- (instancetype)initWithCameraViewComponentView:(CKCameraViewComponentView *)viewComponentView {
+    if (self = [super init]) {
+        _viewComponentView = viewComponentView;
+    }
+    return self;
+}
+
+- (void)onReadCodeWithCodeStringValue:(NSString *)codeStringValue codeFormat:(NSString *)codeFormat {
+    if ([_viewComponentView eventEmitter] != nullptr) {
+        auto cameraEventEmitter = std::static_pointer_cast<const facebook::react::CKCameraEventEmitter>([_viewComponentView eventEmitter]);
+        cameraEventEmitter->onReadCode({.codeStringValue = [codeStringValue UTF8String], .codeFormat = [codeFormat UTF8String]});
+    }
+}
+
+- (void)onOrientationChangeWithOrientation:(NSInteger)orientation {
+    if ([_viewComponentView eventEmitter] != nullptr) {
+        auto cameraEventEmitter = std::static_pointer_cast<const facebook::react::CKCameraEventEmitter>([_viewComponentView eventEmitter]);
+        cameraEventEmitter->onOrientationChange({.orientation = (int)orientation});
+    }
+}
+
+- (void)onZoomWithZoom:(double)zoom {
+    // log zoom
+    NSLog(@"Zoom sent: %f", zoom);
+    if ([_viewComponentView eventEmitter] != nullptr) {
+        auto cameraEventEmitter = std::static_pointer_cast<const facebook::react::CKCameraEventEmitter>([_viewComponentView eventEmitter]);
+        cameraEventEmitter->onZoom({.zoom = zoom});
+    }
+}
+
+- (void)onCaptureButtonPressIn {
+    if ([_viewComponentView eventEmitter] != nullptr) {
+        auto cameraEventEmitter = std::static_pointer_cast<const facebook::react::CKCameraEventEmitter>([_viewComponentView eventEmitter]);
+        cameraEventEmitter->onCaptureButtonPressIn({});
+    }
+}
+
+- (void)onCaptureButtonPressOut {
+    if ([_viewComponentView eventEmitter] != nullptr) {
+        auto cameraEventEmitter = std::static_pointer_cast<const facebook::react::CKCameraEventEmitter>([_viewComponentView eventEmitter]);
+        cameraEventEmitter->onCaptureButtonPressOut({});
+    }
+}
+
+@end
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/ReactNativeCameraKit/SimulatorCamera.swift
+++ b/ios/ReactNativeCameraKit/SimulatorCamera.swift
@@ -10,8 +10,8 @@ import UIKit
  * Fake camera implementation to be used on simulator
  */
 class SimulatorCamera: CameraProtocol {
-    private var onOrientationChange: RCTDirectEventBlock?
-    private var onZoom: RCTDirectEventBlock?
+    private weak var eventEmitter: CameraEventEmitter?
+
     private var videoDeviceZoomFactor: Double = 1.0
     private var videoDeviceMaxAvailableVideoZoomFactor: Double = 150.0
     private var wideAngleZoomFactor: Double = 2.0
@@ -49,7 +49,7 @@ class SimulatorCamera: CameraProtocol {
             return
         }
 
-        self.onOrientationChange?(["orientation": orientation.rawValue])
+        self.eventEmitter?.onOrientationChange(orientation: orientation.rawValue)
     }
 
     func cameraRemovedFromSuperview() {
@@ -57,12 +57,8 @@ class SimulatorCamera: CameraProtocol {
 
     }
 
-    func update(onOrientationChange: RCTDirectEventBlock?) {
-        self.onOrientationChange = onOrientationChange
-    }
-
-    func update(onZoom: RCTDirectEventBlock?) {
-        self.onZoom = onZoom
+    func update(eventEmitter: CameraEventEmitter?) {
+        self.eventEmitter = eventEmitter
     }
 
     func setVideoDevice(zoomFactor: Double) {
@@ -74,7 +70,6 @@ class SimulatorCamera: CameraProtocol {
     func zoomPinchStart() {
         DispatchQueue.main.async {
             self.zoomStartedAt = self.videoDeviceZoomFactor
-            self.mockPreview.zoomLabel.text = "Zoom start"
         }
     }
 
@@ -95,7 +90,7 @@ class SimulatorCamera: CameraProtocol {
                 if self.zoom == nil {
                     self.setVideoDevice(zoomFactor: zoomForDevice)
                 }
-                self.onZoom?(["zoom": zoomForDevice])
+                self.eventEmitter?.onZoom(zoom: zoomForDevice)
             }
         }
     }
@@ -160,7 +155,7 @@ class SimulatorCamera: CameraProtocol {
             // If they wanted to reset, tell them what the default zoom turned out to be
             // regardless if it's controlled
             if self.zoom == nil || zoom == 0 {
-                self.onZoom?(["zoom": zoomForDevice])
+                self.eventEmitter?.onZoom(zoom: zoomForDevice)
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #691 by refactoring how events are sent back to React.

Created an interface that is implemented differently between the old/new arch

Code is safer as it uses methods with enforced parameters, and all the piping is centralized and specific to each arch

## How did you test this change?

Tested on iOS, with old arch and new arch
Will send videos later today