### PR TITLE
Add file size (bytes) to capture() result on Android

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -432,6 +432,10 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
                     imageInfo.putInt("height", height)
                     imageInfo.putString("path", path)
 
+                    val imageFile = File(path)
+                    val imageSize = imageFile.length() // size in bytes
+                    imageInfo.putDouble("size", imageSize.toDouble()) 
+                    
                     promise.resolve(imageInfo)
                 } catch (ex: Exception) {
                     Log.e(TAG, "Error while saving or decoding saved photo: ${ex.message}", ex)


### PR DESCRIPTION
## Summary
The `capture()`method on Android did not include the _image file size_ in its returned metadata. This PR adds a new size field (in bytes) to the capture result so developers can access the file size directly without using external filesystem libraries.

## Problem
Before this change, capture() returned only:
```
{
  "uri": "file:///path/to/photo.jpg",
  "width": 1080,
  "height": 1920,
  "name": "IMG_1234.jpg"
}
```
## Solution
- On Android, after saving the captured photo to disk, the implementation now uses:
 `file.length()`
 to compute the file size.
- The size value is added to the result map and returned to JS.
- Example updated response:
```
{
  uri: "file:///path/to/photo.jpg",
  width: 1080,
  height: 1920,
  name: "IMG_1234.jpg",
  size: 345678   // bytes
}
```

## Notes
- **Android only:** iOS implementation remains unchanged.
- **Backward-compatible:** Existing consumers are unaffected.
- The new field is optional and safe to ignore if not needed.


## Test Plan

- **Environment:** 
  - React Native version: 0.74.1
  - Android device: Pixel 5 (Android 13)
  - Also tested on Android Emulator (API 31)

- **Steps** performed:
  - Launched the example app included in the repo.
  - Granted camera permissions.
  - Captured multiple photos using cameraRef.capture().
  - Logged the returned object to the console.
  - Verified that the new size field appeared in the response.
  - Cross-checked the reported size with react-native-fs.stat(uri) → both matched

- **Results:**
  - ✅ size field was present in the capture result.
  - ✅ Value was correct (matched actual file size in bytes).
  - ✅ No regressions in existing fields (uri, width, height, name).