### PR TITLE
Fixed torch not being enabled on startup #593

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2223,7 +2223,7 @@ PODS:
     - React-perflogger (= 0.81.0)
     - React-utils (= 0.81.0)
     - SocketRocket
-  - ReactNativeCameraKit (16.0.1):
+  - ReactNativeCameraKit (16.1.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2528,14 +2528,14 @@ SPEC CHECKSUMS:
   React-performancetimeline: 1f86dc9782e3fe78727c5fbb3e2178b9fd1aa6fd
   React-RCTActionSheet: 550c9c6c2e7dcd85a51954dc08e2f3837a148e7c
   React-RCTAnimation: 19d4bb6d2190983d1354b096b7b65dbd591924da
-  React-RCTAppDelegate: 4512132c26eb717a81d4a0b6516f178639e9abf0
+  React-RCTAppDelegate: 6c71d16eef920831a312ff363355fc3b99c02a98
   React-RCTBlob: b81a0cffe1a083bcf9d8aa9f27f4d37864579e90
-  React-RCTFabric: e256e79bdab3d2c4bb6e5975224484d0f42131f3
-  React-RCTFBReactNativeSpec: 8442e61116ea32de3fc3664651f7a78da11c6ba0
+  React-RCTFabric: 01005d2fa799bba6e21aae18820498f56fe0be5f
+  React-RCTFBReactNativeSpec: 5adb84a81c4ed7a1f2661835d166e4b2c4320cd4
   React-RCTImage: 607e5e373fb56d72417464bd82e8046af81ab502
   React-RCTLinking: 301434c7bf1100458be5a3866326ba33491e3687
   React-RCTNetwork: a118a47bd123ac96c9877e04f5731a1d6545aba5
-  React-RCTRuntime: b1e67bc601a330d1f72c71246557541efbc121a4
+  React-RCTRuntime: 85fdbf469fe8a12c4db6c836731b190efc33d11d
   React-RCTSettings: 5a5aa2cf9ac40f7a8897cc0f9d945ac803886604
   React-RCTText: e6e00bee9847a8af1218079b73c8bfed16c75b8d
   React-RCTVibration: 5a05fa0ef05ee73d074a3314e57586afc969f1ba
@@ -2552,10 +2552,10 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: c91900fa724baee992f01c05eeb4c9e01a807f78
   ReactCodegen: a55799cae416c387aeaae3aabc1bc0289ac19cee
   ReactCommon: 116d6ee71679243698620d8cd9a9042541e44aa6
-  ReactNativeCameraKit: 29206675814ffb96b09a200b999ad5fa9b858a08
+  ReactNativeCameraKit: b01e637c97fb6eefe43eff31917d1410fc77e1f8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 00013dd9cde63a2d98e8002fcc4f5ddb66c10782
 
-PODFILE CHECKSUM: 2a7cb4991754518b63a1c5b884f5861886abdce4
+PODFILE CHECKSUM: 831b9773c4c6aed2643524d13cb247994d19e1e9
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
## Summary

Fixes torch mode not being enabled when camera starts. This is odd behavior of videoDevice.lockForConfiguration() which reset torch mode every time it's reconfigured. The fix is to always set torch mode every time we lock it for other changes.

## How did you test this change? (ios, iphone 14 pro)

1. Hard-code `torchMode="on"` for the `<Camera>` component.
2. Start the camera
3. Change to Front camera (which has no flash light)
4. Change to Back camera (which has flash light)
5. (flash light should come on)