### PR TITLE
Adds Documentation

### DIFF
--- a/.github/workflows/docset.yml
+++ b/.github/workflows/docset.yml
@@ -1,0 +1,79 @@
+name: Build Docs and Docset
+
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install sqlite3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sqlite3
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build TypeDoc HTML
+        run: yarn docs:build
+
+      - name: Build Dash docset
+        run: yarn docset:build
+
+      - name: Verify docset index
+        run: |
+          set -euo pipefail
+          DB=docs/react-native-camera-kit.docset/Contents/Resources/docSet.dsidx
+          COUNT=$(sqlite3 "$DB" "select count(*) from searchIndex;")
+          echo "Indexed entries: $COUNT"
+          test "$COUNT" -gt 0
+          TYPE=$(sqlite3 "$DB" "select type from searchIndex where name='Camera' limit 1;")
+          echo "Camera entry type: $TYPE"
+          test "$TYPE" = "Component"
+
+      - name: Upload TypeDoc HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: typedoc-site
+          path: docs/site
+          retention-days: 7
+
+      - name: Zip Dash docset
+        run: |
+          cd docs
+          zip -r react-native-camera-kit.docset.zip react-native-camera-kit.docset
+
+      - name: Upload Dash docset
+        uses: actions/upload-artifact@v4
+        with:
+          name: react-native-camera-kit.docset.zip
+          path: docs/react-native-camera-kit.docset.zip
+          retention-days: 7
+
+      - name: Attach to GitHub Release (tags only)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            docs/react-native-camera-kit.docset.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,12 @@ yarn-error.log
 
 # Project specific
 
+# Generated documentation artifacts (do not commit)
+docs/site/
+docs/*.docset/
+docs/*.docset
+docs/*.docset.zip
+
 example/.yarn/*
 !example/.yarn/patches
 !example/.yarn/plugins

--- a/README.md
+++ b/README.md
@@ -262,3 +262,18 @@ If you are using Expo Managed Workflow, you can use this library with a third-pa
 The MIT License.
 
 See [LICENSE](LICENSE)
+
+## Documentation and Dash Docset
+
+- Build API docs (TypeDoc HTML):
+  - `yarn docs:build` → outputs to `docs/site`
+  - `yarn docs:serve` → serves `docs/site` at `http://localhost:8080` (set a custom port with `DOCS_PORT=9000`)
+
+- Build Dash docset locally:
+  - `yarn docset:build` → creates `docs/react-native-camera-kit.docset`
+  - In Dash: Preferences → Docsets → “+” → Add Local Docset → select `docs/react-native-camera-kit.docset`
+
+- CI artifacts:
+  - Every push/PR builds TypeDoc and the Dash docset on Ubuntu (no macOS required).
+  - Artifacts: `typedoc-site` (HTML) and `react-native-camera-kit.docset` are uploaded in GitHub Actions.
+  - On tagged releases (`vX.Y.Z`), the `.docset` is attached to the GitHub Release.

--- a/docs/tsdoc-style.md
+++ b/docs/tsdoc-style.md
@@ -1,0 +1,112 @@
+# TSDoc Style Guide (react-native-camera-kit)
+
+Purpose: Make API docs consistent, complete, and TypeDoc-friendly so we can generate high‑quality site/Dash output.
+
+Scope: Public TypeScript surface only (everything exported from `src`). Native spec files under `src/specs` are internal and should be tagged `@internal`.
+
+## General Rules
+- Audience: App developers using this library in React Native apps.
+- Voice: Direct, actionable, present tense. Avoid “This function…”.
+- One‑line summary first; end with a period.
+- Expand with a short paragraph under `@remarks` when useful (behavior, caveats, platform notes).
+- Prefer small, runnable `@example` blocks in TSX using functional components and `useRef`.
+- Put platform constraints in remarks as “Platform: iOS” / “Platform: Android”.
+- Use `@defaultValue` to document defaults (including sentinel `-1` used to represent “unset” due to RN Codegen limits).
+- Use `@deprecated`, `@since`, and `@see` when applicable.
+- Group with `@category` so TypeDoc sections are tidy: Components, Imperative API, Types, Enums, Events, Constants, Native Module.
+- Mark non‑public items with `@internal`.
+
+## Tag Cheat Sheet
+- `@public` for exported APIs (optional; exported implies public, but keep it explicit on top‑level items).
+- `@remarks` for nuanced behavior, platform notes, and warnings.
+- `@example` for concise TS/TSX usage.
+- `@param` and `@returns` for functions/methods.
+- `@defaultValue` for props/parameters with defaults.
+- `@see` to cross‑link related APIs or README sections.
+- `@deprecated`, `@since` as needed.
+
+## Component Props (interfaces)
+Document each prop with a short summary, then specifics in remarks. Include platform and default when relevant.
+
+Example pattern:
+
+```ts
+/**
+ * Controls zoom. Higher values zoom in.
+ *
+ * @remarks
+ * - Default optical baseline is `1.0` (wide‑angle).
+ * - Platform: iOS, Android.
+ * - If `zoomMode` is `on`, treat `zoom` as uncontrolled (omit or set to `undefined`).
+ *
+ * @defaultValue 1.0 (device‑dependent minimum may be < 1.0)
+ * @example
+ * ```tsx
+ * const [zoom, setZoom] = useState(1.0);
+ * <Camera
+ *   zoom={zoom}
+ *   onZoom={(e) => setZoom(e.nativeEvent.zoom)}
+ * />
+ * ```
+ */
+zoom?: number;
+```
+
+Event props should describe the `nativeEvent` shape explicitly (even if typed) and when they fire.
+
+## Imperative API (component ref)
+Each method gets a clear contract, return type details, and file URL behavior.
+
+```ts
+/**
+ * Capture a JPEG and return file info.
+ *
+ * @remarks
+ * - Returns a `file://` URI where supported; always a URI string for consistency.
+ * - Move the file to a permanent location if you need it beyond the current session.
+ * - Platform: iOS, Android.
+ *
+ * @returns Promise with `{ uri, name, width, height, size? }`.
+ * @see README: Imperative API › capture()
+ */
+capture(): Promise<CaptureData>;
+```
+
+## Enums, Types, Constants
+- Enums: add a brief description for the enum and each member.
+- String‑literal unions: summarize allowed values where they are used.
+- Constants (e.g., `Orientation`): describe mapping and origin (native constants).
+
+## Platform Nuances to Capture
+- Optional numeric props normalized to `-1` before passing to native (RN Codegen limitation). Document this under each affected prop with `@remarks` and `@defaultValue -1 (treated as unset)` when appropriate.
+- Color props on Android are run through `processColor`.
+- iOS exposes `requestDeviceCameraAuthorization` and `checkDeviceCameraAuthorizationStatus` on the ref; Android throws “Not implemented”. Mark with platform notes.
+
+## Examples — Canonical Snippets
+Use concise TSX with hooks; show imports and refs.
+
+```tsx
+import React, { useRef } from 'react';
+import { Button } from 'react-native';
+import { Camera, type CameraApi } from 'react-native-camera-kit';
+
+export function CaptureExample() {
+  const ref = useRef<CameraApi>(null);
+  return (
+    <>
+      <Camera ref={ref} zoomMode="on" />
+      <Button title="Snap" onPress={async () => {
+        const photo = await ref.current?.capture();
+        console.log(photo?.uri);
+      }} />
+    </>
+  );
+}
+```
+
+## Writing Style Notes
+- Sentence case; keep summaries ≤ 120 characters when possible.
+- Prefer active voice, avoid repetition of type names (“Returns a promise” vs “This method returns…”).
+- Keep examples minimal; highlight just one concept per example.
+- When in doubt, favor clarity over cleverness.
+

--- a/docs/typedoc-custom.css
+++ b/docs/typedoc-custom.css
@@ -1,0 +1,103 @@
+/* Make large Markdown tables responsive and prevent overflow */
+.tsd-typography table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.tsd-typography th,
+.tsd-typography td {
+  /* Reset to saner defaults; specific column rules below */
+  word-break: normal;
+  white-space: nowrap;
+}
+/* Allow inline code in tables to wrap if needed */
+.tsd-typography td code,
+.tsd-typography th code {
+  /* Allow code to wrap only in description column (overridden below) */
+  white-space: nowrap;
+}
+
+/* 3-column prop tables: fix column behavior */
+.tsd-typography table th:nth-child(1),
+.tsd-typography table td:nth-child(1) {
+  min-width: 160px;
+}
+.tsd-typography table th:nth-child(2),
+.tsd-typography table td:nth-child(2) {
+  min-width: 160px;
+}
+.tsd-typography table th:nth-child(3),
+.tsd-typography table td:nth-child(3) {
+  /* Let the description occupy remaining width and wrap nicely */
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: anywhere;
+}
+.tsd-typography table td:nth-child(3) code,
+.tsd-typography table th:nth-child(3) code {
+  white-space: break-spaces;
+}
+
+/* Mobile adjustments: keep columns readable and avoid giant rows */
+@media (max-width: 720px) {
+  .tsd-typography table {
+    display: table;            /* restore native flow */
+    table-layout: fixed;       /* enforce column widths */
+  }
+  .tsd-typography th,
+  .tsd-typography td {
+    white-space: normal;       /* allow wrapping on small screens */
+  }
+  .tsd-typography table th:nth-child(1),
+  .tsd-typography table td:nth-child(1) {
+    width: 32%;
+    min-width: 0;
+  }
+  .tsd-typography table th:nth-child(2),
+  .tsd-typography table td:nth-child(2) {
+    width: 28%;
+    min-width: 0;
+  }
+  .tsd-typography table th:nth-child(3),
+  .tsd-typography table td:nth-child(3) {
+    width: 40%;
+  }
+  .tsd-typography td code,
+  .tsd-typography th code {
+    white-space: break-spaces; /* allow code to break if needed */
+  }
+}
+
+/* Tesla styling for the top toolbar */
+.tsd-page-toolbar {
+  /* Scope variable overrides to toolbar only */
+  --color-background-secondary: #E31937;
+  --dim-toolbar-border-bottom-width: 0;
+  background: var(--color-background-secondary) !important;
+  border-bottom: 0 !important;
+  color: #fff;
+}
+.tsd-page-toolbar a,
+.tsd-page-toolbar .title {
+  color: #fff !important;
+}
+.tsd-page-toolbar a:hover {
+  text-decoration: underline;
+}
+
+/* Dark theme background override */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: #000000;
+  }
+}
+/* Also support manual dark theme selection in UI */
+:root[data-theme="dark"] {
+  --color-background: #000000;
+}
+
+/* Remove footer border */
+body > footer {
+  border-top: 0 !important;
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "clean": "rm -rf dist/",
+    "docs:clean": "rm -rf docs/site",
+    "typedoc:raw": "typedoc",
+    "docs:build": "yarn docs:clean && yarn typedoc:raw && node scripts/postprocess-typedoc.mjs",
+    "docset:clean": "rm -rf docs/react-native-camera-kit.docset",
+    "docset:build": "yarn docs:build && node scripts/build-docset.mjs",
+    "docs:serve": "node scripts/serve-docs.mjs",
     "test": "jest",
     "lint": "yarn eslint -c .eslintrc.js",
     "check-ios": "scripts/check-ios.sh",
@@ -32,6 +38,7 @@
   "dependencies": {},
   "license": "MIT",
   "devDependencies": {
+    "typedoc": "^0.28.12",
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",

--- a/scripts/build-docset.mjs
+++ b/scripts/build-docset.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+import { execFile, spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ROOT = path.join(__dirname, '..');
+const DOCS_HTML_DIR = path.join(ROOT, 'docs', 'site');
+const DOCSET_DIR = path.join(ROOT, 'docs', 'react-native-camera-kit.docset');
+const CONTENTS_DIR = path.join(DOCSET_DIR, 'Contents');
+const RESOURCES_DIR = path.join(CONTENTS_DIR, 'Resources');
+const DOCUMENTS_DIR = path.join(RESOURCES_DIR, 'Documents');
+const DSIDX_PATH = path.join(RESOURCES_DIR, 'docSet.dsidx');
+
+function sh(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { ...opts }, (err, stdout, stderr) => {
+      if (err) return reject(Object.assign(err, { stdout, stderr }));
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+async function ensureDocsBuilt() {
+  try {
+    await fs.access(DOCS_HTML_DIR);
+  } catch {
+    console.log('[docset] docs/site not found; building with TypeDoc…');
+    await sh('yarn', ['docs:build'], { cwd: ROOT });
+  }
+}
+
+async function rimraf(p) {
+  await fs.rm(p, { recursive: true, force: true });
+}
+
+async function mkdirp(p) {
+  await fs.mkdir(p, { recursive: true });
+}
+
+async function copyDir(src, dest) {
+  await mkdirp(dest);
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const e of entries) {
+    const s = path.join(src, e.name);
+    const d = path.join(dest, e.name);
+    if (e.isDirectory()) await copyDir(s, d);
+    else if (e.isSymbolicLink()) {
+      const target = await fs.readlink(s);
+      await fs.symlink(target, d);
+    } else {
+      await fs.copyFile(s, d);
+    }
+  }
+}
+
+function plist(obj) {
+  // Minimal Info.plist writer for Dash docsets
+  const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const entries = Object.entries(obj)
+    .map(([k, v]) => {
+      let xmlVal;
+      if (typeof v === 'boolean') xmlVal = `<${v ? 'true' : 'false'}/>`;
+      else if (typeof v === 'number') xmlVal = `<integer>${v}</integer>`;
+      else xmlVal = `<string>${esc(v)}</string>`;
+      return `    <key>${esc(k)}</key>\n    ${xmlVal}`;
+    })
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+${entries}
+  </dict>
+</plist>\n`;
+}
+
+function mapTypeForPath(relPath, name) {
+  // Map TypeDoc output folders to Dash entry types
+  // See: https://kapeli.com/docsets#supportedentrytypes
+  if (relPath.startsWith('interfaces/')) return 'Interface';
+  if (relPath.startsWith('classes/')) return 'Class';
+  if (relPath.startsWith('enums/')) return 'Enum';
+  if (relPath.startsWith('functions/')) return 'Function';
+  if (relPath.startsWith('types/')) return 'Type';
+  if (relPath.startsWith('variables/')) {
+    if (relPath === 'variables/Camera.html') return 'Component';
+    if (name === 'Orientation') return 'Constant';
+    return 'Variable';
+  }
+  if (relPath === 'index.html') return 'Guide';
+  if (relPath === 'modules.html') return 'Module';
+  return 'Guide';
+}
+
+async function* walk(dir, base = dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(full, base);
+    else yield path.relative(base, full);
+  }
+}
+
+async function buildIndex() {
+  // Build minimal search index from generated HTML structure
+  const records = [];
+  for await (const rel of walk(DOCUMENTS_DIR, DOCUMENTS_DIR)) {
+    if (!rel.endsWith('.html')) continue;
+    // Skip assets pages
+    if (rel.startsWith('assets/') || rel.startsWith('media/')) continue;
+    const base = path.basename(rel, '.html');
+    // Ignore unnamed default page under variables
+    if (rel.startsWith('variables/') && base === 'default') continue;
+    const type = mapTypeForPath(rel, base);
+    const name = base;
+    records.push({ name, type, path: rel });
+  }
+  return records;
+}
+
+async function writeSQLiteIndex(records) {
+  // Ensure sqlite3 CLI exists
+  try {
+    await sh('sqlite3', ['-version']);
+  } catch (e) {
+    throw new Error('sqlite3 CLI not found. Install sqlite3 or adjust the builder to use a JS SQLite lib.');
+  }
+
+  await rimraf(DSIDX_PATH);
+  const stmts = [
+    'PRAGMA encoding="UTF-8";',
+    'PRAGMA journal_mode=DELETE;',
+    'PRAGMA synchronous=OFF;',
+    'PRAGMA busy_timeout=2000;',
+    'CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT);',
+    'CREATE UNIQUE INDEX anchor ON searchIndex(name, type, path);',
+  ];
+  for (const r of records) {
+    const esc = (s) => String(s).replace(/'/g, "''");
+    stmts.push(`INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('${esc(r.name)}','${esc(r.type)}','${esc(r.path)}');`);
+  }
+  // Feed all statements in one go via stdin to avoid interactive hangs
+  await new Promise((resolve, reject) => {
+    const child = spawn('sqlite3', [DSIDX_PATH], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`sqlite3 exited with code ${code}: ${stderr}`));
+      } else {
+        resolve();
+      }
+    });
+    child.stdin.write(stmts.join('\n'));
+    child.stdin.end();
+  });
+}
+
+async function main() {
+  await ensureDocsBuilt();
+  await rimraf(DOCSET_DIR);
+  await mkdirp(DOCUMENTS_DIR);
+  await copyDir(DOCS_HTML_DIR, DOCUMENTS_DIR);
+
+  const info = plist({
+    CFBundleIdentifier: 'com.teslamotors.react-native-camera-kit',
+    CFBundleName: 'React Native Camera Kit',
+    DocSetPlatformFamily: 'react-native',
+    isDashDocset: true,
+    dashIndexFilePath: 'index.html',
+    DashDocSetDefaultFTSEnabled: true,
+    DashDocSetFallbackURL: 'https://github.com/teslamotors/react-native-camera-kit',
+  });
+  await fs.writeFile(path.join(CONTENTS_DIR, 'Info.plist'), info, 'utf8');
+
+  const records = await buildIndex();
+  await writeSQLiteIndex(records);
+
+  console.log(`[docset] Built ${DOCSET_DIR}`);
+  console.log(`[docset] Indexed ${records.length} entries`);
+}
+
+main().catch((err) => {
+  console.error('[docset] Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/postprocess-typedoc.mjs
+++ b/scripts/postprocess-typedoc.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.join(__dirname, '..');
+const CAMERA_PAGE = path.join(ROOT, 'docs', 'site', 'variables', 'Camera.html');
+
+async function rewriteCameraHeading() {
+  try {
+    let html = await fs.readFile(CAMERA_PAGE, 'utf8');
+    // Replace the H1 heading label from "Variable Camera [Const]" to "Component Camera"
+    html = html.replace(/<h1>\s*Variable Camera(?:<code[^>]*>[^<]*<\/code>)?\s*<\/h1>/, '<h1>Component Camera<\/h1>');
+    await fs.writeFile(CAMERA_PAGE, html, 'utf8');
+    console.log('[postprocess] Rewrote Camera heading to "Component Camera"');
+  } catch (e) {
+    console.warn('[postprocess] Camera page not found or rewrite failed:', e.message);
+  }
+}
+
+async function hardenInlineThemeScript() {
+  // Guard localStorage access so environments without it (e.g., some WebViews) don't break navigation
+  const DOCS_DIR = path.join(ROOT, 'docs', 'site');
+  /** @type {string[]} */
+  const stack = [DOCS_DIR];
+  const files = [];
+  while (stack.length) {
+    const dir = stack.pop();
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.endsWith('.html')) files.push(full);
+    }
+  }
+  let patched = 0;
+  for (const f of files) {
+    let html = await fs.readFile(f, 'utf8');
+    const before = html;
+    html = html.replace(
+      /document\.documentElement\.dataset\.theme\s*=\s*localStorage\.getItem\(("|')tsd-theme\1\)\s*\|\|\s*("|')os\2\s*;/,
+      'try{document.documentElement.dataset.theme = localStorage.getItem("tsd-theme") || "os";}catch(_){document.documentElement.dataset.theme = "os";}'
+    );
+    if (html !== before) {
+      await fs.writeFile(f, html, 'utf8');
+      patched++;
+    }
+  }
+  console.log(`[postprocess] Hardened inline theme script in ${patched} file(s)`);
+}
+
+async function convertAsyncScriptsToDefer() {
+  const DOCS_DIR = path.join(ROOT, 'docs', 'site');
+  const files = [];
+  const stack = [DOCS_DIR];
+  while (stack.length) {
+    const dir = stack.pop();
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.endsWith('.html')) files.push(full);
+    }
+  }
+  let patched = 0;
+  for (const f of files) {
+    let html = await fs.readFile(f, 'utf8');
+    const before = html;
+    // Replace async with defer for TypeDoc asset scripts to preserve order
+    html = html.replace(/<script\s+async\s+src=\"assets\/(icons|search|navigation)\.js\"/g, '<script defer src="assets/$1.js"');
+    if (html !== before) {
+      await fs.writeFile(f, html, 'utf8');
+      patched++;
+    }
+  }
+  console.log(`[postprocess] Converted async->defer on ${patched} file(s)`);
+}
+
+async function reorderAssetScripts() {
+  const DOCS_DIR = path.join(ROOT, 'docs', 'site');
+  const files = [];
+  const stack = [DOCS_DIR];
+  while (stack.length) {
+    const dir = stack.pop();
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name.endsWith('.html')) files.push(full);
+    }
+  }
+  let patched = 0;
+  for (const f of files) {
+    let html = await fs.readFile(f, 'utf8');
+    const before = html;
+    // Ensure navigation.js loads before main.js: move main.js defer tag after icons/search/navigation
+    html = html.replace(
+      /(\<link[^>]+custom\.css\"[^>]*\>\s*)(<script[^>]+src=\"assets\/main\.js\"[^>]*><\/script>)([\s\S]*?)(<script[^>]+src=\"assets\/navigation\.js\"[^>]*><\/script>)/,
+      (m, pre, mainTag, middle, navTag) => `${pre}${middle}${navTag}\n${mainTag}`
+    );
+    if (html !== before) {
+      await fs.writeFile(f, html, 'utf8');
+      patched++;
+    }
+  }
+  console.log(`[postprocess] Reordered scripts in ${patched} file(s)`);
+}
+
+await rewriteCameraHeading();
+await hardenInlineThemeScript();
+await convertAsyncScriptsToDefer();
+await reorderAssetScripts();

--- a/scripts/serve-docs.mjs
+++ b/scripts/serve-docs.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import http from 'http';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.join(__dirname, '..');
+const DOCS_DIR = path.join(ROOT, 'docs', 'site');
+
+const PORT = Number(process.env.DOCS_PORT || 8080);
+
+const MIME = new Map(Object.entries({
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.json': 'application/json; charset=utf-8',
+}));
+
+function contentTypeFor(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME.get(ext) || 'application/octet-stream';
+}
+
+async function ensureDocs() {
+  try {
+    await fs.access(DOCS_DIR);
+  } catch {
+    console.error('[docs:serve] docs/site not found. Run `yarn docs:build` first.');
+    process.exit(1);
+  }
+}
+
+function sanitizeUrl(urlPath) {
+  try {
+    const decoded = decodeURIComponent(urlPath.split('?')[0]);
+    // Prevent path traversal
+    const p = path.normalize(decoded).replace(/^\/+/, '');
+    return p;
+  } catch {
+    return 'index.html';
+  }
+}
+
+async function serve() {
+  await ensureDocs();
+
+  const server = http.createServer(async (req, res) => {
+    const rel = sanitizeUrl(req.url || '/');
+    let filePath = path.join(DOCS_DIR, rel);
+
+    try {
+      const st = await fs.stat(filePath).catch(() => null);
+      if (!st) {
+        // Fallback for SPA-style links: try appending .html
+        if (!rel.endsWith('.html')) {
+          const tryHtml = filePath + '.html';
+          const stHtml = await fs.stat(tryHtml).catch(() => null);
+          if (stHtml) filePath = tryHtml;
+        }
+      } else if (st.isDirectory()) {
+        filePath = path.join(filePath, 'index.html');
+      }
+
+      const data = await fs.readFile(filePath);
+      res.writeHead(200, { 'Content-Type': contentTypeFor(filePath) });
+      res.end(data);
+    } catch (e) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not found');
+    }
+  });
+
+  server.listen(PORT, () => {
+    console.log(`[docs:serve] Serving ${DOCS_DIR} at http://localhost:${PORT}`);
+  });
+}
+
+serve().catch((e) => {
+  console.error('[docs:serve] Error:', e);
+  process.exit(1);
+});
+

--- a/src/Camera.android.tsx
+++ b/src/Camera.android.tsx
@@ -5,6 +5,14 @@ import type { CameraProps } from './CameraProps';
 import NativeCamera from './specs/CameraNativeComponent';
 import NativeCameraKitModule from './specs/NativeCameraKitModule';
 
+/**
+ * Android implementation of the {@link Camera} component.
+ *
+ * @remarks
+ * - Exposes `capture(options?)` on the ref. Authorization helpers are not implemented.
+ * - Transforms color props via `processColor`.
+ * - Optional numeric props are normalized to `-1` before passing to native.
+ */
 const Camera = React.forwardRef<CameraApi, CameraProps>((props, ref) => {
   const nativeRef = React.useRef(null);
 

--- a/src/Camera.ios.tsx
+++ b/src/Camera.ios.tsx
@@ -5,6 +5,14 @@ import type { CameraProps } from './CameraProps';
 import NativeCamera from './specs/CameraNativeComponent';
 import NativeCameraKitModule from './specs/NativeCameraKitModule';
 
+/**
+ * iOS implementation of the {@link Camera} component.
+ *
+ * @remarks
+ * - Exposes `capture()`, `requestDeviceCameraAuthorization()` and
+ *   `checkDeviceCameraAuthorizationStatus()` on the ref.
+ * - Optional numeric props are normalized to `-1` before passing to native.
+ */
 const Camera = React.forwardRef<CameraApi, CameraProps>((props, ref) => {
   const nativeRef = React.useRef(null);
 

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -1,10 +1,72 @@
 import { lazy } from 'react';
 import { Platform } from 'react-native';
 
+/**
+ * Cross‑platform camera component for React Native.
+ *
+ * @remarks
+ * Renders a high‑performance preview with photo capture, pinch‑to‑zoom,
+ * tap‑to‑focus (iOS), and optional barcode scanning. The implementation is
+ * platform‑specific and lazy‑loaded (`Camera.ios.tsx` / `Camera.android.tsx`).
+ * Configure via {@link CameraProps}. Access the imperative API via a `ref` of
+ * type {@link CameraApi} for actions like {@link CameraApi.capture | capture()}.
+ *
+ * Key props:
+ * - {@link CameraProps.cameraType | cameraType}: select front/back camera.
+ * - {@link CameraProps.zoomMode | zoomMode}: enable pinch‑to‑zoom gesture.
+ * - {@link CameraProps.zoom | zoom}: programmatic zoom control (omit when using pinch).
+ * - {@link CameraProps.maxZoom | maxZoom}: cap the maximum zoom factor.
+ * - {@link CameraProps.flashMode | flashMode} / {@link CameraProps.torchMode | torchMode}: control flash/torch.
+ * - {@link CameraProps.scanBarcode | scanBarcode} + {@link CameraProps.onReadCode | onReadCode}: barcode scanning.
+ *
+ * @category Components
+ *
+ * @example Basic usage
+ * ```tsx
+ * import React, { useRef } from 'react';
+ * import { Camera, type CameraApi } from 'react-native-camera-kit';
+ * 
+ * export function Example() {
+ *   const ref = useRef<CameraApi>(null);
+ *   return (
+ *     <Camera
+ *       ref={ref}
+ *       style={{ flex: 1 }}
+ *       cameraType="back"
+ *       flashMode="auto"
+ *       zoomMode="on"
+ *       onZoom={(e) => console.log('zoom', e.nativeEvent.zoom)}
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * @example Capture a photo
+ * ```tsx
+ * const snap = async () => {
+ *   const photo = await ref.current?.capture();
+ *   console.log(photo?.uri);
+ * };
+ * ```
+ *
+ * @example Barcode scanning
+ * ```tsx
+ * <Camera
+ *   scanBarcode
+ *   showFrame
+ *   onReadCode={(e) => {
+ *     console.log('barcode', e.nativeEvent.codeStringValue, e.nativeEvent.codeFormat);
+ *   }}
+ * />
+ * ```
+ *
+ * @see {@link CameraProps} for available props
+ * @see {@link CameraApi} for the imperative API
+ * @see {@link Orientation} for orientation values in `onOrientationChange`
+ */
 const Camera = lazy(() =>
   Platform.OS === 'ios'
     ? import('./Camera.ios')
     : import('./Camera.android'),
 );
-
 export default Camera;

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -10,6 +10,12 @@ import {
 } from './types';
 import { Orientation } from './index';
 
+/**
+ * Payload for the {@link CameraProps.onReadCode | onReadCode} event.
+ *
+ * @category Events
+ */
+
 export type OnReadCodeData = {
   nativeEvent: {
     codeStringValue: string;
@@ -17,21 +23,50 @@ export type OnReadCodeData = {
   };
 };
 
+/**
+ * Payload for the {@link CameraProps.onOrientationChange | onOrientationChange} event.
+ *
+ * @remarks
+ * `orientation` maps to {@link Orientation} constants.
+ *
+ * @category Events
+ */
 export type OnOrientationChangeData = {
   nativeEvent: {
     orientation: typeof Orientation[keyof typeof Orientation];
   };
 };
 
+/**
+ * Payload for the {@link CameraProps.onZoom | onZoom} event.
+ *
+ * @category Events
+ */
 export type OnZoom = {
   nativeEvent: {
     zoom: number;
   };
 }
 
+/**
+ * Props for the {@link Camera} component.
+ *
+ * @remarks
+ * - Optional numeric props may be normalized to `-1` internally to represent “unset” (RN Codegen limitation).
+ * - Color props accept numbers or strings; on Android strings are converted via `processColor`.
+ * - Platform-specific behavior is noted per prop.
+ *
+ * @category Components
+ */
 export interface CameraProps extends ViewProps {
   // Behavior
+  /** Flash behavior used for still capture.
+   * @defaultValue `auto`
+   */
   flashMode?: FlashMode;
+  /** Auto-focus mode for the preview.
+   * @defaultValue `on`
+   */
   focusMode?: FocusMode;
   /**
    * Enable or disable the pinch gesture handler.
@@ -43,7 +78,7 @@ export interface CameraProps extends ViewProps {
    * <Camera zoomMode="on" zoom={undefined} />
    * <Camera zoomMode="off" zoom={1.0} />
    * ```
-   */
+  */
   zoomMode?: ZoomMode;
   /**
    * Controls zoom. Higher values zooms in.
@@ -79,8 +114,15 @@ export interface CameraProps extends ViewProps {
    * ```
    */
   maxZoom?: number;
+  /** Continuous torch (flashlight) state while previewing.
+   * @defaultValue `off`
+   */
   torchMode?: TorchMode;
+  /** Selects the active camera device.
+   * @defaultValue `back`
+   */
   cameraType?: CameraType;
+  /** Fires when the device orientation changes (see {@link Orientation}). */
   onOrientationChange?: (event: OnOrientationChangeData) => void;
   /**
    * Callback triggered when user pinches to zoom and on startup.
@@ -97,24 +139,53 @@ export interface CameraProps extends ViewProps {
   /** **Android only**. Triggered when camera fails to initialize */
   onError?: (event: { nativeEvent: { errorMessage: string } }) => void;
   // Barcode only
+  /** Enable barcode scanning.
+   * @defaultValue `false`
+   */
   scanBarcode?: boolean;
+  /** Show an on‑screen frame overlay when scanning.
+   * @defaultValue `false`
+   */
   showFrame?: boolean;
+  /** Color of the moving laser indicator (when `showFrame` is true). */
   laserColor?: number | string;
+  /** Color of the frame outline (when `showFrame` is true). */
   frameColor?: number | string;
+  /** Frame size used to guide scanning focus. */
   barcodeFrameSize?: { width: number; height: number };
+  /** Emitted when a barcode is successfully read. */
   onReadCode?: (event: OnReadCodeData) => void;
   // Specific to iOS
+  /** Show a ratio overlay guide over the preview (no cropping). Example: `'16:9'`. */
   ratioOverlay?: string;
+  /** Color of the ratio overlay.
+   * @defaultValue `#ffffff77`
+   */
   ratioOverlayColor?: number | string;
+  /** Dismiss tap‑to‑focus after this many milliseconds. `0` disables.
+   * @defaultValue `0`
+   */
   resetFocusTimeout?: number;
+  /** Dismiss tap‑to‑focus when the subject area changes (iOS feature).
+   * @defaultValue `true`
+   */
   resetFocusWhenMotionDetected?: boolean;
+  /** Scaling mode for the preview inside the view bounds. */
   resizeMode?: ResizeMode;
-  /** Throttle how often the barcode scanner triggers a new scan */
+  /** Throttle how often the barcode scanner triggers a new scan
+   * @defaultValue `2000`
+   */
   scanThrottleDelay?: number;
-  /** **iOS Only**. 'speed' provides 60-80% faster image capturing */
+  /** **iOS Only**. 'speed' provides 60-80% faster image capturing
+   * @defaultValue `balanced`
+   */
   maxPhotoQualityPrioritization?: 'balanced' | 'quality' | 'speed';
-  /** **Android only**. Play a shutter capture sound when capturing a photo */
+  /** **Android only**. Play a shutter capture sound when capturing a photo
+   * @defaultValue `true`
+   */
   shutterPhotoSound?: boolean;
+  /** Emitted when the hardware capture/volume button is pressed. */
   onCaptureButtonPressIn?: ({ nativeEvent: {} }) => void;
+  /** Emitted when the hardware capture/volume button is released. */
   onCaptureButtonPressOut?: ({ nativeEvent: {} }) => void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,18 +11,73 @@ import {
   type ZoomMode,
   type ResizeMode,
 } from './types';
+import type { CameraProps } from './CameraProps';
 
 const { CameraKit } = NativeModules;
 
-// Start with portrait/pointing up, increment while moving counter-clockwise
+/**
+ * Orientation constants reported by the native camera implementation.
+ *
+ * @remarks
+ * Values start at portrait (top of device up) and increment counter‑clockwise.
+ * These mirror native constants exposed by the underlying modules on iOS and Android.
+ * Use them to interpret orientation values in `onOrientationChange` events.
+ *
+ * Mapping:
+ * - `PORTRAIT` = 0
+ * - `LANDSCAPE_LEFT` = 1
+ * - `PORTRAIT_UPSIDE_DOWN` = 2
+ * - `LANDSCAPE_RIGHT` = 3
+ *
+ * @category Constants
+ */
 export const Orientation = {
   PORTRAIT: 0, // ⬆️
   LANDSCAPE_LEFT: 1, // ⬅️
   PORTRAIT_UPSIDE_DOWN: 2, // ⬇️
   LANDSCAPE_RIGHT: 3, // ➡️
-};
+} as const;
 
+/**
+ * Low‑level native module.
+ *
+ * @remarks
+ * Most apps should use the {@link Camera} component and its ref API instead of
+ * calling this module directly. The available methods are platform‑dependent:
+ *
+ * - iOS: capture plus camera authorization helpers.
+ * - Android: capture; authorization helpers are not implemented.
+ *
+ * @category Native Module
+ * @hidden
+ */
 export default CameraKit;
 
+/**
+ * Cross‑platform camera component.
+ *
+ * @remarks
+ * This is a lazy re‑export; the actual implementation is platform‑specific
+ * (`Camera.ios.tsx` / `Camera.android.tsx`). Attach a `ref` of type
+ * {@link CameraApi} to access imperative methods such as `capture()`.
+ * See {@link CameraProps | Camera props} for configuration.
+ *
+ * @category Components
+ */
 export { Camera, CameraType };
-export type { TorchMode, FlashMode, FocusMode, ZoomMode, CameraApi, CaptureData, ResizeMode };
+
+/**
+ * Public types re‑exported for convenience.
+ *
+ * @category Types
+ */
+export type {
+  TorchMode,
+  FlashMode,
+  FocusMode,
+  ZoomMode,
+  CameraApi,
+  CaptureData,
+  ResizeMode,
+  CameraProps,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,18 @@
+/**
+ * Selects which physical camera to use.
+ *
+ * @category Enums
+ */
 export enum CameraType {
   Front = 'front',
   Back = 'back',
 }
 
+/**
+ * Supported barcode formats.
+ *
+ * @category Types
+ */
 export type CodeFormat =
   | 'code-128'
   | 'code-39'
@@ -18,16 +28,28 @@ export type CodeFormat =
   | 'data-matrix'
   | 'unknown';
 
+/** Torch (flashlight) mode during preview. */
 export type TorchMode = 'on' | 'off';
 
+/** Flash mode used for still capture. */
 export type FlashMode = 'on' | 'off' | 'auto';
 
+/** Auto-focus mode for preview. */
 export type FocusMode = 'on' | 'off';
 
+/** Whether pinch-to-zoom is enabled. */
 export type ZoomMode = 'on' | 'off';
 
+/** How to scale/crop the preview content. */
 export type ResizeMode = 'cover' | 'contain';
 
+/**
+ * Result of a successful capture.
+ *
+ * @remarks
+ * `uri` is a file URI where supported; always a URI string for consistency.
+ * `size` is only returned on iOS.
+ */
 export type CaptureData = {
   uri: string;
   name: string;
@@ -40,8 +62,31 @@ export type CaptureData = {
   size?: number;
 };
 
+/**
+ * Imperative API available from {@link Camera} via `ref`.
+ *
+ * @category Imperative API
+ */
 export type CameraApi = {
+  /**
+   * Capture a JPEG and return file information.
+   *
+   * @returns Promise resolved with {@link CaptureData}.
+   */
   capture: () => Promise<CaptureData>;
+  /**
+   * Request camera authorization from the user.
+   *
+   * @remarks
+   * Platform: iOS. On Android this method is not implemented and the platform
+   * permission flow should be handled by an external library (see README).
+   */
   requestDeviceCameraAuthorization: () => Promise<boolean>;
+  /**
+   * Check current camera authorization status.
+   *
+   * @remarks
+   * Platform: iOS. On Android this method is not implemented.
+   */
   checkDeviceCameraAuthorizationStatus: () => Promise<boolean>;
 };

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.json",
+  "name": "react-native-camera-kit",
+  "out": "docs/site",
+  "readme": "README.md",
+  "exclude": [
+    "src/specs/**/*"
+  ],
+  "excludeExternals": false,
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeNotDocumented": true,
+  "includeVersion": true,
+  "categorizeByGroup": true,
+  "visibilityFilters": {
+    "protected": false,
+    "private": false,
+    "inherited": true,
+    "external": true
+  },
+  "searchCategoryBoosts": {
+    "Components": 2,
+    "Imperative API": 2
+  },
+  "githubPages": false,
+  "customCss": ["docs/typedoc-custom.css"],
+  "navigationLinks": {
+    "GitHub": "https://github.com/teslamotors/react-native-camera-kit",
+    "Tesla": "https://www.tesla.com"
+  },
+  "customFooterHtml": "Made by <a href=\"https://www.tesla.com\" target=\"_blank\" rel=\"noreferrer noopener\">Tesla</a> · Source on <a href=\"https://github.com/teslamotors/react-native-camera-kit\" target=\"_blank\" rel=\"noreferrer noopener\">GitHub</a>",
+  "validation": {
+    "invalidLink": true,
+    "notExported": false
+  },
+  "highlightLanguages": ["ts", "tsx", "js", "json", "xml", "java", "kotlin", "swift", "bash"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,6 +1046,17 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@gerrit0/mini-shiki@^3.12.0":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@gerrit0/mini-shiki/-/mini-shiki-3.12.2.tgz#228b6ab36a0fb8a7912fabe26059c9e820630fc7"
+  integrity sha512-HKZPmO8OSSAAo20H2B3xgJdxZaLTwtlMwxg0967scnrDlPwe6j5+ULGHyIqwgTbFCn9yv/ff8CmfWZLE9YKBzA==
+  dependencies:
+    "@shikijs/engine-oniguruma" "^3.12.2"
+    "@shikijs/langs" "^3.12.2"
+    "@shikijs/themes" "^3.12.2"
+    "@shikijs/types" "^3.12.2"
+    "@shikijs/vscode-textmate" "^10.0.2"
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -1571,6 +1582,41 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
+"@shikijs/engine-oniguruma@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-3.12.2.tgz#3314a43666d751f80c0d1fc584029a3074af4e9a"
+  integrity sha512-hozwnFHsLvujK4/CPVHNo3Bcg2EsnG8krI/ZQ2FlBlCRpPZW4XAEQmEwqegJsypsTAN9ehu2tEYe30lYKSZW/w==
+  dependencies:
+    "@shikijs/types" "3.12.2"
+    "@shikijs/vscode-textmate" "^10.0.2"
+
+"@shikijs/langs@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-3.12.2.tgz#f41f1e0eb940c5c41f1017f8765be969e74a0c9b"
+  integrity sha512-bVx5PfuZHDSHoBal+KzJZGheFuyH4qwwcwG/n+MsWno5cTlKmaNtTsGzJpHYQ8YPbB5BdEdKU1rga5/6JGY8ww==
+  dependencies:
+    "@shikijs/types" "3.12.2"
+
+"@shikijs/themes@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-3.12.2.tgz#e4b9b636669658576cdc532ebe1c405cadba6272"
+  integrity sha512-fTR3QAgnwYpfGczpIbzPjlRnxyONJOerguQv1iwpyQZ9QXX4qy/XFQqXlf17XTsorxnHoJGbH/LXBvwtqDsF5A==
+  dependencies:
+    "@shikijs/types" "3.12.2"
+
+"@shikijs/types@3.12.2", "@shikijs/types@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-3.12.2.tgz#8f7f02a1fd67a93470aac9409d072880b3148612"
+  integrity sha512-K5UIBzxCyv0YoxN3LMrKB9zuhp1bV+LgewxuVwHdl4Gz5oePoUFrr9EfgJlGlDeXCU1b/yhdnXeuRvAnz8HN8Q==
+  dependencies:
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.4"
+
+"@shikijs/vscode-textmate@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz#a90ab31d0cc1dfb54c66a69e515bf624fa7b2224"
+  integrity sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
@@ -1647,6 +1693,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hast@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
+  integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -1701,6 +1754,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/unist@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -2691,6 +2749,11 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 env-paths@^2.2.1:
   version "2.2.1"
@@ -4049,6 +4112,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  dependencies:
+    uc.micro "^2.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -4114,12 +4184,29 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 makeerror@1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.12.tgz#3e5dd2079a82e812e983cc6610c4a2cb0eaa801a"
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+markdown-it@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
+  integrity sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
 
 marky@^1.2.2:
   version "1.3.0"
@@ -4130,6 +4217,11 @@ math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -4391,7 +4483,7 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^9.0.4:
+minimatch@^9.0.4, minimatch@^9.0.5:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
@@ -4763,6 +4855,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -5567,10 +5664,26 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
+typedoc@^0.28.12:
+  version "0.28.12"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.28.12.tgz#1baa55ab242e237fc896bc01b57cf5f8bd995d32"
+  integrity sha512-H5ODu4f7N+myG4MfuSp2Vh6wV+WLoZaEYxKPt2y8hmmqNEMVrH69DAjjdmYivF4tP/C2jrIZCZhPalZlTU/ipA==
+  dependencies:
+    "@gerrit0/mini-shiki" "^3.12.0"
+    lunr "^2.3.9"
+    markdown-it "^14.1.0"
+    minimatch "^9.0.5"
+    yaml "^2.8.1"
+
 typescript@^5.8.3:
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+
+uc.micro@^2.0.0, uc.micro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"
@@ -5802,7 +5915,7 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^2.2.1:
+yaml@^2.2.1, yaml@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.1.tgz#1870aa02b631f7e8328b93f8bc574fac5d6c4d79"
   integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==


### PR DESCRIPTION
# Documentation: TypeDoc Site, Dash Docset and CI

## Summary
This PR introduces a complete documentation pipeline for `react-native-camera-kit`, delivering a polished TypeDoc site and a Dash-ready docset. It also adds Tesla-themed styling, responsive improvements, and a robust CI workflow to build and distribute documentation artifacts on every change and release.

## Highlights

### TypeScript API docs
- Comprehensive TSDoc added across the public surface (`Camera`, `CameraProps`, enums/types).
- Camera docs significantly enriched: clear overview, “Key props” quick list, and three practical examples (basic usage, capture, barcode scanning).
- Cross-links throughout (`CameraProps`, `CameraApi`, `Orientation`).
- Noisy default export hidden; internal/native codegen details excluded.

### TypeDoc configuration and theming
- Upgraded to TypeDoc 0.28 with a dedicated config (`typedoc.json`).
- Tesla look-and-feel: red header, dark theme background `#000`, removed footer border.
- Responsive docs: tables no longer overflow; desktop and mobile layouts optimized.
- Header links (GitHub, Tesla) and footer attribution rendered statically (no JS).

### Local dev tooling
- `yarn docs:build` → builds TypeDoc HTML and runs deterministic postprocessing.
- `yarn docs:serve` → lightweight Node server to view docs locally (http://localhost:8080).
- TSDoc authoring guide under `docs/tsdoc-style.md` to keep contributions consistent.

### Dash docset generation
- Custom Node script (`scripts/build-docset.mjs`) packages the TypeDoc site into a `.docset`:
  - Creates `Info.plist`, copies HTML, and builds a SQLite search index.
  - Maps `Camera` to “Component” (improves search semantics in Dash).
- Postprocess script (`scripts/postprocess-typedoc.mjs`) ensures reliability in WebViews (Dash):
  - Guards `localStorage` access, converts `async` → `defer`, and reorders assets for stable init.
  - Rewrites Camera heading to “Component Camera” for clarity.
- `yarn docset:build` → one-command docset build; artifacts ignored via `.gitignore`.

### CI workflow (Ubuntu, no macOS dependency)
- Builds TypeDoc HTML and Dash docset on push/PR and tags.
- Verifies index (> 0) and asserts `Camera` is type “Component”.
- Uploads artifacts (typedoc-site, docset ZIP); attaches ZIP to GitHub Releases for tags.
- Adds concurrency guard to avoid overlapping builds.

## Why this matters
- Clearer API guidance and examples lower integration friction.
- Dash docset supports instant, offline search for developers.
- Automated, Linux-based builds make docs reproducible and release-friendly.

## How to test locally
- HTML: `yarn docs:build && yarn docs:serve` → open http://localhost:8080
- Docset: `yarn docset:build` → import `docs/react-native-camera-kit.docset` in Dash

## Follow-ups (optional)
- Add a docset icon (`icon.png`, `icon@2x.png`) and reference in `Info.plist`.
- Publish TypeDoc HTML to GitHub Pages from CI.
- Expand examples (barcode overlays, permission flows) and add more platform gotchas.

Thanks for reviewing!

