### PR TITLE
Define `files` array to exclude files in the published bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "dist",
     "ios",
     "src",
-    "LICENSE",
     "ReactNativeCameraKit.podspec"
   ],
   "license": "MIT",


### PR DESCRIPTION
## Summary

While working on adding a new metadata information to the React Native Directory, and analysing the results, I have spotted that `react-native-camera-kit` published package includes few redundant files (GitHub workflows, lint and local config files, etc.), which increase a tiny bit the final bundle size, see:
* https://www.npmjs.com/package/react-native-camera-kit?activeTab=code

To make sure that only needed files are included when preparing npm bundle, I have added the `files` array to the `package.json` file, and listed all important directories and files, ref:
* https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files

## How did you test this change?

To test the changes I have run `npm pack --dry-run` command locally before and after the change, and verified that not needed files are omitted from the bundle.

Output before the change:
```
npm notice filename: react-native-camera-kit-16.1.2.tgz
npm notice package size: 120.2 kB
npm notice unpacked size: 354.9 kB
npm notice shasum: 448d9f49ebb0f52175a3239c5e1c742626040a56
npm notice integrity: sha512-Vbz4NqpomuNIE[...]j2VUPL0isgqbw==
npm notice total files: 130
```

Output after the change:

```
npm notice filename: react-native-camera-kit-16.1.2.tgz
npm notice package size: 114.2 kB
npm notice unpacked size: 340.0 kB
npm notice shasum: 9c07d4e31f86b2f6163510ee540d55a34641e31e
npm notice integrity: sha512-jXIvoK2mXwkr8[...]soivwkwnSi1xw==
npm notice total files: 104
```
