### PR TITLE
fix: catch error in cameraProviderFuture.get()

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -186,7 +186,17 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
         val cameraProviderFuture = ProcessCameraProvider.getInstance(getActivity())
         cameraProviderFuture.addListener({
             // Used to bind the lifecycle of cameras to the lifecycle owner
-            cameraProvider = cameraProviderFuture.get()
+            try {
+                cameraProvider = cameraProviderFuture.get()
+            } catch (exc: Exception) {
+                val rootCause = exc.cause?.cause?.message ?: exc.cause?.message ?: exc.message ?: "Camera initialization failed"
+                Log.e(TAG, "Camera initialization failed: $rootCause", exc)
+                val surfaceId = UIManagerHelper.getSurfaceId(currentContext)
+                UIManagerHelper
+                    .getEventDispatcherForReactTag(currentContext, id)
+                    ?.dispatchEvent(ErrorEvent(surfaceId, id, rootCause))
+                return@addListener
+            }
 
             // Rotate the image according to device orientation, even when UI orientation is locked
             orientationListener = object : OrientationEventListener(context, SensorManager.SENSOR_DELAY_UI) {


### PR DESCRIPTION
## Handle camera initialization failures gracefully instead of crashing the app.

On devices or emulators without cameras, ProcessCameraProvider.getInstance().get() throws an exception that was previously uncaught, causing the app to crash. This change catches the exception and dispatches an ErrorEvent to the JS layer via the onError callback.

The error message extracts the root cause from nested exceptions for cleaner error reporting (e.g., "Device reporting less cameras than anticipated. Available cameras: 0" instead of a wrapped ExecutionException).

closes #756

## How did you test this change?

  - Tested on Android emulator without camera configured - app no longer crashes, onError callback fires with descriptive message
  - Tested on Android device with camera - camera works normally