### PR TITLE
fix(android): add missing setIOsSleepBeforeStarting stub for new arch

### DIFF
--- a/android/src/newarch/java/com/rncamerakit/CKCameraManager.kt
+++ b/android/src/newarch/java/com/rncamerakit/CKCameraManager.kt
@@ -155,6 +155,8 @@ class CKCameraManager(context: ReactApplicationContext) : SimpleViewManager<CKCa
     }
 
     // Methods only available on iOS
+    override fun setIOsSleepBeforeStarting(view: CKCamera?, value: Int) = Unit
+
     override fun setRatioOverlay(view: CKCamera?, value: String?) = Unit
 
     override fun setRatioOverlayColor(view: CKCamera?, value: Int?) = Unit


### PR DESCRIPTION
## Summary

- Add missing `setIOsSleepBeforeStarting` method stub to Android new architecture `CKCameraManager`
- This iOS-only prop was added to the component spec but the Android implementation was not updated
- Fixes Kotlin compilation error: `Class 'CKCameraManager' is not abstract and does not implement abstract member`

## How did you test this change?

- [x] Successfully build Android release APK
- [x] Verify camera functionality still works on Android
- [x] Verify no regression on iOS

