### PR TITLE
Add iOS 15.4+ barcode formats and update CodeFormatIOS enum

### DIFF
--- a/ios/ReactNativeCameraKit/CodeFormat.swift
+++ b/ios/ReactNativeCameraKit/CodeFormat.swift
@@ -11,8 +11,8 @@ import AVFoundation
 enum CodeFormat: String, CaseIterable {
     case code128 = "code-128"
     case code39 = "code-39"
+    case code39Mod43 = "code-39-mod-43"
     case code93 = "code-93"
-    case codabar = "codabar"
     case ean13 = "ean-13"
     case ean8 = "ean-8"
     case itf14 = "itf-14"
@@ -21,17 +21,35 @@ enum CodeFormat: String, CaseIterable {
     case pdf417 = "pdf-417"
     case aztec = "aztec"
     case dataMatrix = "data-matrix"
-    case code39Mod43 = "code-39-mod-43"
     case interleaved2of5 = "interleaved-2of5"
     case unknown = "unknown"
+    @available(iOS 15.4, *)
+    case codabar = "codabar"
+    @available(iOS 15.4, *)
+    case gs1DataBar = "gs1-data-bar"
+    @available(iOS 15.4, *)
+    case gs1DataBarLimited = "gs1-data-bar-limited"
+    @available(iOS 15.4, *)
+    case gs1DataBarExpanded = "gs1-data-bar-expanded"
+
+    static var allCases: [CodeFormat] {
+        var supportedBarcodeTypes: [CodeFormat] =
+        [.upce, .code39, .code39Mod43,
+         .ean13, .ean8, .code93, .code128,
+         .pdf417, .qr, .itf14, .aztec,
+         .dataMatrix, .interleaved2of5]
+        
+        if #available(iOS 15.4, *) {
+            supportedBarcodeTypes.append(contentsOf: [
+                .codabar, .gs1DataBar, .gs1DataBarLimited, .gs1DataBarExpanded
+            ])
+        }
+        
+        return supportedBarcodeTypes
+    }
 
     // Convert from AVMetadataObject.ObjectType to CodeFormat
     static func fromAVMetadataObjectType(_ type: AVMetadataObject.ObjectType) -> CodeFormat {
-        if #available(iOS 15.4, *) {
-            if (type == .codabar) {
-                return .codabar
-            }
-        }
         switch type {
         case .code128: return .code128
         case .code39: return .code39
@@ -46,17 +64,20 @@ enum CodeFormat: String, CaseIterable {
         case .aztec: return .aztec
         case .dataMatrix: return .dataMatrix
         case .interleaved2of5: return .interleaved2of5
+        @available(iOS 15.4, *)
+        case .codabar: return .codabar
+        @available(iOS 15.4, *)
+        case .gs1DataBar: return .gs1DataBar
+        @available(iOS 15.4, *)
+        case .gs1DataBarLimited: return .gs1DataBarLimited
+        @available(iOS 15.4, *)
+        case .gs1DataBarExpanded: return .gs1DataBarExpanded
         default: return .unknown
         }
     }
 
     // Convert from CodeFormat to AVMetadataObject.ObjectType
     func toAVMetadataObjectType() -> AVMetadataObject.ObjectType {
-        if #available(iOS 15.4, *) {
-            if (self == .codabar) {
-                return .codabar
-            }
-        }
         switch self {
         case .code128: return .code128
         case .code39: return .code39
@@ -71,8 +92,15 @@ enum CodeFormat: String, CaseIterable {
         case .aztec: return .aztec
         case .dataMatrix: return .dataMatrix
         case .interleaved2of5: return .interleaved2of5
-        case .unknown: fallthrough
-        default: return .init(rawValue: "unknown")
+        @available(iOS 15.4, *)
+        case .codabar: return .codabar
+        @available(iOS 15.4, *)
+        case .gs1DataBar: return .gs1DataBar
+        @available(iOS 15.4, *)
+        case .gs1DataBarLimited: return .gs1DataBarLimited
+        @available(iOS 15.4, *)
+        case .gs1DataBarExpanded: return .gs1DataBarExpanded
+        case .unknown: return .init(rawValue: "unknown")
         }
     }
 }

--- a/ios/ReactNativeCameraKit/CodeFormat.swift
+++ b/ios/ReactNativeCameraKit/CodeFormat.swift
@@ -5,8 +5,8 @@
 //  Created by Imdad on 2023-12-22.
 //
 
-import Foundation
 import AVFoundation
+import Foundation
 
 enum CodeFormat: String, CaseIterable {
     case code128 = "code-128"
@@ -17,14 +17,14 @@ enum CodeFormat: String, CaseIterable {
     case ean8 = "ean-8"
     case itf14 = "itf-14"
     case upce = "upc-e"
-    case qr = "qr"
+    case qr
     case pdf417 = "pdf-417"
-    case aztec = "aztec"
+    case aztec
     case dataMatrix = "data-matrix"
     case interleaved2of5 = "interleaved-2of5"
-    case unknown = "unknown"
+    case unknown
     @available(iOS 15.4, *)
-    case codabar = "codabar"
+    case codabar
     @available(iOS 15.4, *)
     case gs1DataBar = "gs1-data-bar"
     @available(iOS 15.4, *)
@@ -34,17 +34,17 @@ enum CodeFormat: String, CaseIterable {
 
     static var allCases: [CodeFormat] {
         var supportedBarcodeTypes: [CodeFormat] =
-        [.upce, .code39, .code39Mod43,
-         .ean13, .ean8, .code93, .code128,
-         .pdf417, .qr, .itf14, .aztec,
-         .dataMatrix, .interleaved2of5]
-        
+            [.upce, .code39, .code39Mod43,
+             .ean13, .ean8, .code93, .code128,
+             .pdf417, .qr, .itf14, .aztec,
+             .dataMatrix, .interleaved2of5]
+
         if #available(iOS 15.4, *) {
             supportedBarcodeTypes.append(contentsOf: [
                 .codabar, .gs1DataBar, .gs1DataBarLimited, .gs1DataBarExpanded
             ])
         }
-        
+
         return supportedBarcodeTypes
     }
 
@@ -64,16 +64,20 @@ enum CodeFormat: String, CaseIterable {
         case .aztec: return .aztec
         case .dataMatrix: return .dataMatrix
         case .interleaved2of5: return .interleaved2of5
-        @available(iOS 15.4, *)
-        case .codabar: return .codabar
-        @available(iOS 15.4, *)
-        case .gs1DataBar: return .gs1DataBar
-        @available(iOS 15.4, *)
-        case .gs1DataBarLimited: return .gs1DataBarLimited
-        @available(iOS 15.4, *)
-        case .gs1DataBarExpanded: return .gs1DataBarExpanded
-        default: return .unknown
+        default: break
         }
+
+        if #available(iOS 15.4, *) {
+            switch type {
+            case .codabar: return .codabar
+            case .gs1DataBar: return .gs1DataBar
+            case .gs1DataBarLimited: return .gs1DataBarLimited
+            case .gs1DataBarExpanded: return .gs1DataBarExpanded
+            default: break
+            }
+        }
+
+        return .unknown
     }
 
     // Convert from CodeFormat to AVMetadataObject.ObjectType
@@ -92,15 +96,19 @@ enum CodeFormat: String, CaseIterable {
         case .aztec: return .aztec
         case .dataMatrix: return .dataMatrix
         case .interleaved2of5: return .interleaved2of5
-        @available(iOS 15.4, *)
-        case .codabar: return .codabar
-        @available(iOS 15.4, *)
-        case .gs1DataBar: return .gs1DataBar
-        @available(iOS 15.4, *)
-        case .gs1DataBarLimited: return .gs1DataBarLimited
-        @available(iOS 15.4, *)
-        case .gs1DataBarExpanded: return .gs1DataBarExpanded
-        case .unknown: return .init(rawValue: "unknown")
+        default: break
         }
+
+        if #available(iOS 15.4, *) {
+            switch self {
+            case .codabar: return .codabar
+            case .gs1DataBar: return .gs1DataBar
+            case .gs1DataBarLimited: return .gs1DataBarLimited
+            case .gs1DataBarExpanded: return .gs1DataBarExpanded
+            default: break
+            }
+        }
+
+        return .init(rawValue: "unknown")
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,6 @@ const codeFormatIOS = [
   'code-128',
   'code-39',
   'code-93',
-  'codabar', // only iOS 15.4+
   'ean-13',
   'ean-8',
   'itf-14',
@@ -35,6 +34,10 @@ const codeFormatIOS = [
   'data-matrix',
   'code-39-mod-43',
   'interleaved-2of5',
+  'codabar', // iOS 15.4+
+  'gs1-data-bar', // iOS 15.4+
+  'gs1-data-bar-limited', // iOS 15.4+
+  'gs1-data-bar-expanded', // iOS 15.4+
 ] as const;
 
 export const supportedCodeFormats = Array.from(new Set([...codeFormatAndroid, ...codeFormatIOS]));


### PR DESCRIPTION
# Support additional barcode formats from iOS 15.4+

## Summary

This PR adds support for additional barcode formats available in iOS 15.4+:
- `codabar`
- `gs1-data-bar`
- `gs1-data-bar-limited`
- `gs1-data-bar-expanded`

### Motivation

Previously, these formats were enabled via a `patch-package` workaround in my apps. since the new feature for `allowedBarcodeTypes` was introduced, this change integrates them directly into the codebase using proper availability annotations.

### Note

This feature is currently **iOS-only** (specifically iOS 15.4+). Android support remains unchanged pending the availability of these formats in the native Android camera APIs. (I'm a iOS only developer so I lack the expertise for Android)

## Changes

- Updated `CodeFormat.swift` enum with new barcode types and proper `@available` annotations
-  Unified switch statements in conversion methods using inline availability checks
-  Added new formats to `codeFormatIOS` in `types.ts` with iOS 15.4+ documentation
-  Updated `allCases` property to conditionally include iOS 15.4+ formats

## How did you test this change?

Tested on **iOS 15.4+** simulator/device:
- [x] All new barcode formats are recognized and properly converted
- [x] `allCases` correctly includes iOS 15.4+ formats on supported versions
- [x] Backwards compatibility maintained for iOS < 15.4 (availability checks prevent crashes)
- [x] Type definitions align with Swift enum implementation

**Screenshots/Testing Results:**
