### PR TITLE
Fix the initial state for flashMode and torchMode

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -103,6 +103,8 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
     private var maxZoom: Double? = null
     private var zoomStartedAt = 1.0f
     private var pinchGestureStartedAt = 0.0f
+    private var flashMode: String = "auto"
+    private var torchMode: String = "off"
 
     // Barcode Props
     private var scanBarcode: Boolean = false
@@ -405,6 +407,10 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
 
             resetZoom(newCamera)
 
+            // Apply initial flash mode and torch mode settings after camera initialization
+            setFlashMode(flashMode)
+            setTorchMode(torchMode)
+
             // Attach the viewfinder's surface provider to preview use case
             preview?.setSurfaceProvider(viewFinder.surfaceProvider)
         } catch (exc: Exception) {
@@ -588,6 +594,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
 
 
     fun setFlashMode(mode: String?) {
+        flashMode = mode ?: "auto"
         val imageCapture = imageCapture ?: return
         val camera = camera ?: return
         when (mode) {
@@ -607,6 +614,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
     }
 
     fun setTorchMode(mode: String?) {
+        torchMode = mode ?: "off"
         val camera = camera ?: return
         when (mode) {
             "on" -> {


### PR DESCRIPTION
## Summary

Fix for #518.

On Android, when passing an initial or static value for the `flashMode` or `torchMode` props that should result in the flash turning on, the value is not actually applied to the camera and the flash does not turn on.  With a simple example such as: `<Camera torchMode="on" />` the flash/torch does not turn on.  Similarly `<Camera flashMode="on" />` (or `"auto"` in a low-light environment) does not turn the flash on during photo capture.  The same goes for a state variable with an initial value that should turn the flash on such as:
```javascript
const [torchMode, setTorchMode] = useState(true);
return <Camera torchMode={torchMode} />;
```

However changing those values based on user input (i.e. using a state variable) or even a `setTimeout()` in a `useEffect()` like [one of the proposed workarounds in #518](https://github.com/teslamotors/react-native-camera-kit/issues/518#issuecomment-1623236436) after the camera has initialized **does** work.

This PR resolves that issue by setting the `flashMode` and `torchMode` after the camera has initialized.


## How did you test this change?

Tested on a few different Android devices using the examples above.