### PR TITLE
Exclude generated build output from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "release": "yarn clean && yarn build && yarn publish --verbose",
     "release:beta": "yarn clean && yarn build && yarn publish --tag beta --verbose",
     "release:local": "yarn clean && yarn build && tmp=$(mktemp) && yarn pack --filename $tmp.tar.gz && open -R $tmp.tar.gz",
+    "prepack": "rm -rf android/build build",
     "start": "watchman watch-del-all && node node_modules/react-native/local-cli/cli.js start",
     "codegen": "react-native codegen --verbose --path . --platform ios --source library && react-native codegen --verbose --path . --platform android --source library",
     "bootstrap": "cd example/ && bundle install && yarn && cd ios/ && bundle exec pod install",
@@ -31,7 +32,7 @@
   "react-native": "src/index",
   "files": [
     "android",
-    "build",
+    "!android/build",
     "dist",
     "ios",
     "src",


### PR DESCRIPTION
Closes: #769 

LONG VERSION
---

CameraKit ships a dirty android/build folder in npm.
That folder contains old generated C++ files.
When our app builds:
1. yarn installs CameraKit.
2. CameraKit already contains: `android/build/generated/...`
3. RN 0.83 tries to generate its own files into that same folder.
4. But Gradle sometimes skips the cleanup step because it thinks schema generation is already up-to-date.
5. So RN writes new files on top of old files.
6. One old .cpp remains: (`NativeCameraKitSpecJSI-generated.cpp`)
7. That old .cpp expects `NativeCameraKitModuleCxxSpecJSI`
8. RN 0.83’s new header no longer has that class.
9. C++ compile fails.

SHORT VERSION
---


RNCK ships old generated files.
RN 0.83 generates new files with new conventions.
Old and new files get mixed.
C++ compiler explodes.

<img width="821" height="514" alt="image" src="https://github.com/user-attachments/assets/47516f78-5495-47be-bc8b-e6c6a0d103ce" />
