### PR TITLE
fix(android): bind scan/face without ImageCapture on LIMITED cameras

### DIFF
--- a/android/src/main/java/com/rncamerakit/CKCamera.kt
+++ b/android/src/main/java/com/rncamerakit/CKCamera.kt
@@ -331,32 +331,35 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
         // CameraSelector
         val cameraSelector = CameraSelector.Builder().requireLensFacing(lensType).build()
 
-        // Preview
-        preview = Preview.Builder()
-                // We request aspect ratio but no resolution
-                .setTargetAspectRatio(previewAspectRatio)
-                // Set initial target rotation
-                .setTargetRotation(rotation)
-                .build()
+        val analyzing = scanBarcode || faceDetectionEnabled
+
+        // Avoid setTargetAspectRatio while analyzing: RN view size often forces an impossible
+        // CameraX maxSize on LIMITED cameras / emulator webcams.
+        val previewBuilder = Preview.Builder().setTargetRotation(rotation)
+        if (!analyzing) {
+            previewBuilder.setTargetAspectRatio(previewAspectRatio)
+        }
+        preview = previewBuilder.build()
 
         // ImageCapture
         imageCapture = ImageCapture.Builder()
             .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
-            // We request aspect ratio but no resolution to match preview config, but letting
-            // CameraX optimize for whatever specific resolution best fits our use cases
             .setTargetAspectRatio(previewAspectRatio)
-            // Set initial target rotation, we will have to call this again if rotation changes
-            // during the lifecycle of this use case
             .setTargetRotation(rotation)
             .build()
 
-        // ImageAnalysis
+        // VGA is enough for ML Kit and binds on LIMITED hardware.
+        @Suppress("DEPRECATION")
         imageAnalyzer = ImageAnalysis.Builder()
             .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-            .setTargetAspectRatio(previewAspectRatio)
+            .setTargetResolution(Size(640, 480))
             .build()
 
-        val useCases = mutableListOf(preview, imageCapture)
+        // Analysis mode: Preview + ImageAnalysis only. ImageCapture as a 3rd stream breaks LIMITED cameras.
+        val useCases = mutableListOf<UseCase>(preview!!)
+        if (!analyzing) {
+            useCases.add(imageCapture!!)
+        }
 
         faceAnalyzer?.close()
         faceAnalyzer = null
@@ -431,7 +434,7 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
                 if (tasks.isEmpty()) image.close()
                 else Tasks.whenAllComplete(tasks).addOnCompleteListener { image.close() }
             }
-            useCases.add(imageAnalyzer)
+            useCases.add(imageAnalyzer!!)
         }
 
         // Must unbind the use-cases before rebinding them
@@ -732,13 +735,14 @@ class CKCamera(context: ThemedReactContext) : FrameLayout(context), LifecycleObs
     fun setScanBarcode(enabled: Boolean) {
         val restartCamera = enabled != scanBarcode
         scanBarcode = enabled
-        if (restartCamera) bindCameraUseCases()
+        // Props can arrive before ProcessCameraProvider is ready; setupCamera() will bind later.
+        if (restartCamera && cameraProvider != null) bindCameraUseCases()
     }
 
     fun setFaceDetectionEnabled(enabled: Boolean) {
         val restartCamera = enabled != faceDetectionEnabled
         faceDetectionEnabled = enabled
-        if (restartCamera) bindCameraUseCases()
+        if (restartCamera && cameraProvider != null) bindCameraUseCases()
     }
 
     fun setFaceDetectionThrottleMs(throttleMs: Int) {


### PR DESCRIPTION
## Summary

On LIMITED cameras (common with Android emulator webcams), binding `Preview` + `ImageCapture` + `ImageAnalysis` fails with:

```text
All supported output sizes are filtered out according to current resolution selection settings.
maxSize = 640x320
initial size list: [1920x1080, 1280x720, 640x480]
```

The preview stays black even though the system Camera app works.

When `scanBarcode` or face detection is on, this PR binds **Preview + ImageAnalysis only** (capture isn't used in that mode), skips view-derived `setTargetAspectRatio` on Preview, and targets VGA for analysis.

Photo-capture path is unchanged (`Preview` + `ImageCapture`).

Also: don't call `bindCameraUseCases()` from scan/face props before `ProcessCameraProvider` is ready.

## Test plan

- [ ] Physical device: barcode scan still works
- [ ] Physical device: take picture still works (`scanBarcode` off)
- [ ] Emulator with webcam: Scan screen shows live preview (not black)
- [ ] Emulator: barcodes still detect via ML Kit
- [ ] Face detection still works if enabled


Made with [Cursor](https://cursor.com)